### PR TITLE
chore: initial setup to support a fleet of Nomad clients

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,26 @@ jobs:
       - name: Perform flake check
         run: nix flake check --all-systems
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v30
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.28.1/install
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Perform colmena build
+        run: nix run .#build
+
   ci_pass:
     if: always()
     needs:
       - lint
+      - build
     runs-on: Ubuntu-latest
     steps:
       - name: Decide whether the required jobs succeeded or failed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: "CI"
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v30
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.28.1/install
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Perform flake check
+        run: nix flake check --all-systems
+
+  ci_pass:
+    if: always()
+    needs:
+      - lint
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Decide whether the required jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/colmena-apply.yaml
+++ b/.github/workflows/colmena-apply.yaml
@@ -1,0 +1,44 @@
+name: "Apply changes to all nodes"
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v30
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.28.1/install
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - name: Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          use-cache: true
+
+      - name: Perform colmena apply
+        run: nix run .#apply
+
+  ci_pass:
+    if: always()
+    needs:
+      - apply
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Decide whether the required jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/colmena-apply.yaml
+++ b/.github/workflows/colmena-apply.yaml
@@ -31,14 +31,3 @@ jobs:
 
       - name: Perform colmena apply
         run: nix run .#apply
-
-  ci_pass:
-    if: always()
-    needs:
-      - apply
-    runs-on: Ubuntu-latest
-    steps:
-      - name: Decide whether the required jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Direnv output dir
+.direnv
+
+# Pre-commit hooks file as it is managed by Nix
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ system.
 The first step is to add a new machine "node" with a unique name to the
 `Colmena` definition in the [flake.nix](flake.nix).
 
-Do this by adding an entry under `outputs.flake.colmena.<your-machine-name>`:
+Do this by adding an entry under `outputs.flake.colmena.<your-machine-name>`.
+The entry needs to contain any configuration specific to this new machine, for
+example the root directory `fileSystems` entry from the generated
+`hardware-configuration.nix` file.
 
 ```nix
 outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
@@ -40,7 +43,12 @@ outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       # ...other config...
 
       <your-machine-name> = _: {
-        # ...machine-specific config here...
+        fileSystems."/" = {
+          device = "/dev/disk/by-uuid/<uuid-of-main-drive>";
+          fsType = "ext4";
+        };
+
+        # ...other machine-specific config here...
       };
     };
 };

--- a/README.md
+++ b/README.md
@@ -84,6 +84,26 @@ manager shared vault).
 Now navigate to <https://login.tailscale.com/admin/machines> and confirm that
 the new machine is there.
 
+#### Password Access
+
+> \[!Warning\]
+> The password is hashed with a random salt and SSH access is managed via
+> Tailscale so it should be safe enough to share. However, know that if you
+> allow access to this machine to the public then password access via SSH
+> should be disabled.
+
+Once the machine is added as a Colmena node, the password is set in the
+[flake.nix](flake.nix) file and cannot be changed manually. You should not need
+the password as you can SSH via Tailscale without it but the password is in the
+password manager's shared vault under `Nomad Client Root Password`.
+
+##### Changing the Password
+
+To change the password, generate a new one in the password manager's shared
+vault and then use `mkpasswd` to generate the hash and set the value of
+`users.users.root.hashedPassword` in the `defaults` to change the password for
+all nodes.
+
 ### Disable key expiration
 
 By default all nodes need a new key every 90 days. For these machines it is

--- a/README.md
+++ b/README.md
@@ -24,22 +24,26 @@ system.
 The first step is to add a new machine "node" with a unique name to the
 `Colmena` definition in the [flake.nix](flake.nix).
 
-Do this by adding an entry under `outputs.colmena.<your-machine-name>`:
+Do this by adding an entry under `outputs.flake.colmena.<your-machine-name>`:
 
 ```nix
-outputs = { ... }@inputs:
-  let
-    system = "x86_64-linux";
-    pkgs = import inputs.nixpkgs { inherit system; };
-  in
-  {
-    colmena = {
-        # ...other config...
-      <your-machine-name> = { ... }: {
-        # ...machine-specific config here...
-      }
-    };
+outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+  perSystem = { ... }: {
+    # ...other config...
   };
+
+  flake.colmena =
+    let
+      targetSystem = "x86_64-linux";
+    in
+    {
+      # ...other config...
+
+      <your-machine-name> = _: {
+        # ...machine-specific config here...
+      };
+    };
+};
 ```
 
 Make sure that your machine's name is unique and add any configuration that

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The first step is to add a new machine "node" with a unique name to the
 Do this by adding an entry under `outputs.flake.colmena.<your-machine-name>`.
 The entry needs to contain any configuration specific to this new machine, for
 example the root directory `fileSystems` entry from the generated
-`hardware-configuration.nix` file.
+`hardware-configuration.nix` file, usually found in `/etc/nixos`.
 
 ```nix
 outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Commit and push these changes to a new branch.
 
 ### Registering the new machine
 
-Now that you have a branch with the definition of your new machine on it, on
-the new machine run the command:
+Now that you have a branch with the definition of your new machine on it, log
+into the new machine with the account you created during installation or root
+and run the command:
 
 ```sh
 nix --experimental-features 'nix-command flakes' run github:holochain/wind-tunnel-runner/<your-branch> -- <your-machine-name>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Go to <https://nixos.org/download/#nixos-iso> to get the ISO and install NixOS.
 Feel free to use any of the installation ISOs but the graphical one is easier.
 
 Follow the NixOS installation guide as normal, create any user you want with
-any password as this can all be overwritten by `Colmena` and we will only use
+any password as this user will be overwritten by `Colmena` and we will only use
 the root account with SSH key access. A graphical desktop environment is
 probably not needed so just select `No desktop` when asked.
 
@@ -56,8 +56,13 @@ Commit and push these changes to a new branch.
 
 Now that you have a branch with the definition of your new machine on it, make
 sure that the machine has internet access, preferably a wired one for
-stability, and log into the new machine with the root account or the one you
-created during installation and run the command:
+stability.
+
+Then, log into the machine with the root account and run the command:
+
+> \[!Warning\]
+> Must use the `root` account as all other accounts will be deleted during
+> installation.
 
 ```sh
 nix --experimental-features 'nix-command flakes' run github:holochain/wind-tunnel-runner/<your-branch> -- <your-machine-name>

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Commit and push these changes to a new branch.
 
 ### Registering the new machine
 
-Now that you have a branch with the definition of your new machine on it, log
-into the new machine with the account you created during installation or root
-and run the command:
+Now that you have a branch with the definition of your new machine on it, make
+sure that the machine has internet access, preferably a wired one for
+stability, and log into the new machine with the root account or the one you
+created during installation and run the command:
 
 ```sh
 nix --experimental-features 'nix-command flakes' run github:holochain/wind-tunnel-runner/<your-branch> -- <your-machine-name>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,81 @@
 # wind-tunnel-runner
-The guide and NixOS configuration for setting up a machine to run Wind Tunnel scenarios
+
+The guide and NixOS configuration for setting up a machine to run Wind Tunnel
+scenarios
+
+## Adding a node
+
+### Installing NixOS
+
+Go to <https://nixos.org/download/#nixos-iso> to get the ISO and install NixOS.
+
+Feel free to use any of the installation ISOs but the graphical one is easier.
+
+Follow the NixOS installation guide as normal, create any user you want with
+any password as this can all be overwritten by `Colmena` and we will only use
+the root account with SSH key access. A graphical desktop environment is
+probably not needed so just select `No desktop` when asked.
+
+Once the installation is finished, remove the live-NixOS USB and restart the
+system.
+
+### Adding new machine
+
+The first step is to add a new machine "node" with a unique name to the
+`Colmena` definition in the [flake.nix](flake.nix).
+
+Do this by adding an entry under `outputs.colmena.<your-machine-name>`:
+
+```nix
+outputs = { ... }@inputs:
+  let
+    system = "x86_64-linux";
+    pkgs = import inputs.nixpkgs { inherit system; };
+  in
+  {
+    colmena = {
+        # ...other config...
+      <your-machine-name> = { ... }: {
+        # ...machine-specific config here...
+      }
+    };
+  };
+```
+
+Make sure that your machine's name is unique and add any configuration that
+differs from the default. For example, if your boot device is not `/dev/sda`
+then change `boot.loader.grub.device` and `fileSystems."/".device` accordingly.
+
+Commit and push these changes to a new branch.
+
+### Registering the new machine
+
+Now that you have a branch with the definition of your new machine on it, on
+the new machine run the command:
+
+```sh
+nix --experimental-features 'nix-command flakes' run github:holochain/wind-tunnel-runner/<your-branch> -- <your-machine-name>
+```
+
+After the install, you will be prompted to log into Tailscale via a URL.
+Navigate to this URL on any device and login with the
+`holochain-release-automation2` GitHub account (credentials are in password
+manager shared vault).
+
+Now navigate to <https://login.tailscale.com/admin/machines> and confirm that
+the new machine is there.
+
+### Disable key expiration
+
+By default all nodes need a new key every 90 days. For these machines it is
+recommended to instead set the key to never expire so that we don't need to
+manually update the keys.
+
+To do this go to <https://login.tailscale.com/admin/machines> and select the
+`...` dropdown on the right of the machine and select `Disable key expiry`.
+
+### Checking the machine in Nomad
+
+Now that the machine is registered on Tailscale, navigate to
+<https://nomad-server-01.holochain.org:4646/ui/clients> and check that the
+machine is also in the list of available Nomad clients.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,191 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1737689766,
+        "narHash": "sha256-ivVXYaYlShxYoKfSo5+y5930qMKKJ8CLcAoIBPQfJ6s=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fe74265bbb6d016d663b1091f015e2976c4a527",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "hc-launch": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734474851,
+        "narHash": "sha256-OtXwvb97Qt+xh/K4+voy60kMnpPZvEoqoe2Bgkn+Nro=",
+        "owner": "holochain",
+        "repo": "hc-launch",
+        "rev": "ca598033225d8ee3df7911c1cbde6004182e84eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "holochain-0.4",
+        "repo": "hc-launch",
+        "type": "github"
+      }
+    },
+    "hc-scaffold": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741874486,
+        "narHash": "sha256-TRFWZ2oDP5VTPrPQ+EqliB8az9hEfZA8n/0taFiWCa8=",
+        "owner": "holochain",
+        "repo": "scaffolding",
+        "rev": "433856eab13dae7532a1692461da8c521a7c964d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "holochain-0.4",
+        "repo": "scaffolding",
+        "type": "github"
+      }
+    },
+    "holochain": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741629985,
+        "narHash": "sha256-0AwinPJL4F10cQvZWmFSQRFYG0cwFIg0zEg123/g738=",
+        "owner": "holochain",
+        "repo": "holochain",
+        "rev": "e37bc3f71943bbcfde5d39ab934de4d3e78dec05",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "holochain-0.4.2",
+        "repo": "holochain",
+        "type": "github"
+      }
+    },
+    "holonix": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "hc-launch": "hc-launch",
+        "hc-scaffold": "hc-scaffold",
+        "holochain": "holochain",
+        "lair-keystore": "lair-keystore",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1741880193,
+        "narHash": "sha256-6CvuF3L7DO1x/R+vS+f00nx3n9tfMd5JMu7uq8PCGC0=",
+        "owner": "holochain",
+        "repo": "holonix",
+        "rev": "2d11f668dfcef076c5252428965a134a4aa167c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "main-0.4",
+        "repo": "holonix",
+        "type": "github"
+      }
+    },
+    "lair-keystore": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732721902,
+        "narHash": "sha256-D8sXIpOptaXib5bc6zS7KsGzu4D08jaL8Fx1W/mlADE=",
+        "owner": "holochain",
+        "repo": "lair",
+        "rev": "e82937521ae9b7bdb30c8b0736c13cd4220a0223",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "lair_keystore-v0.5.3",
+        "repo": "lair",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1738023785,
+        "narHash": "sha256-BPHmb3fUwdHkonHyHi1+x89eXB3kA1jffIpwPVJIVys=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2b4230bf03deb33103947e2528cac2ed516c5c89",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "holonix": "holonix",
+        "nixpkgs": [
+          "holonix",
+          "nixpkgs"
+        ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "holonix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738117527,
+        "narHash": "sha256-GFviGfaezjGLFUlxdv3zyC7rSZvTXqwcG/YsF6MDkOw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6a3dc6ce4132bd57359214d986db376f2333c14d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -30,6 +46,27 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -155,13 +192,40 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-parts": [
+          "holonix",
+          "flake-parts"
+        ],
         "holonix": "holonix",
         "nixpkgs": [
           "holonix",
           "nixpkgs"
-        ]
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,10 @@
         text = ''
           cd ${./.}
           ${pkgs.colmena}/bin/colmena apply-local --sudo --impure "$@"
+          while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
+            sleep 0.5
+          done
+          ${pkgs.tailscale}/bin/tailscale up --ssh
         '';
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,17 @@
             allowLocalDeployment = true;
           };
 
+          nix = {
+            # Extra lines to be added to /etc/nix/nix.conf
+            extraOptions = "experimental-features = nix-command flakes";
+
+            # Add wind-tunnel substituters
+            settings = {
+              substituters = [ "https://cache.nixos.org" "https://holochain-ci.cachix.org" "https://holochain-wind-tunnel.cachix.org" ];
+              trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=" "holochain-wind-tunnel.cachix.org-1:tnSm+7Y3hDKOc9xLdoVMuInMA2AQ0R/99Ucz5edYGJw=" ];
+            };
+          };
+
           system.stateVersion = "24.11";
 
           networking.hostName = name;

--- a/flake.nix
+++ b/flake.nix
@@ -27,11 +27,9 @@
           fsType = "ext4";
         };
 
-        users.users.holochain = {
-          isNormalUser = true;
-          description = "Holochain Dev Account";
-          extraGroups = [ "networkmanager" "wheel" ];
-          hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";
+        users = {
+          mutableUsers = false;
+          users.root.hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";
         };
 
         services.tailscale = {

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,12 @@
           device = "/dev/sda1";
           fsType = "ext4";
         };
+
+        users.users.holochain = {
+          isNormalUser = true;
+          description = "Holochain Dev Account";
+          extraGroups = [ "networkmanager" "wheel" ];
+        };
       };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -51,8 +51,14 @@
       packages.${system}.default = pkgs.writeShellApplication {
         name = "setup-script";
         text = ''
+          if [[ -v 1 ]]; then
+              node="$1"
+          else
+              read -r -p "Enter node name: " node
+          fi
+
           cd ${./.}
-          ${pkgs.colmena}/bin/colmena apply-local --sudo --impure "$@"
+          ${pkgs.colmena}/bin/colmena apply-local --sudo --impure --node="$node"
           while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
             sleep 0.5
           done

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
             while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
               sleep 0.5
             done
-            ${pkgs.tailscale}/bin/tailscale up --ssh --hostname="$node"
+            ${pkgs.tailscale}/bin/tailscale up --ssh --advertise-tags=tag:nomad-client --hostname="$node"
 
             echo "Installation complete"
             echo "It is recommended to reboot for the hostname to take effect."

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "NixOS configuration for a Nomad client, deployed using Colmena";
+
+  inputs = {
+    holonix.url = "github:holochain/holonix?ref=main-0.4";
+    nixpkgs.follows = "holonix/nixpkgs";
+  };
+
+  outputs = { ... }@inputs: {
+    colmena = {
+      meta = {
+        nixpkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+        };
+      };
+
+      nomad-client = { ... }: {
+        deployment = {
+          allowLocalDeployment = true;
+        };
+        boot.loader.grub.device = "/dev/sda";
+        fileSystems."/" = {
+          device = "/dev/sda1";
+          fsType = "ext4";
+        };
+      };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -177,6 +177,13 @@
             };
           };
         };
+
+        nomad-client-1 = _: {
+          fileSystems."/" = {
+            device = "/dev/disk/by-uuid/a92690a8-d96c-4305-bfd9-ac4cf7f1c9e6";
+            fsType = "ext4";
+          };
+        };
       };
 
   };

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
           };
         };
 
-        defaults = { name, pkgs, ... }: {
+        defaults = { name, pkgs, lib, ... }: {
           deployment = {
             allowLocalDeployment = true;
           };
@@ -135,7 +135,10 @@
 
           networking.hostName = name;
 
-          boot.loader.grub.device = "/dev/sda";
+          boot.loader = lib.mkDefault {
+            systemd-boot.enable = true;
+            efi.canTouchEfiVariables = true;
+          };
 
           users = {
             mutableUsers = false;

--- a/flake.nix
+++ b/flake.nix
@@ -98,7 +98,7 @@
 
         build = pkgs.writeShellApplication {
           name = "build-script";
-          text = "${pkgs.colmena}/bin/colmena build --impure";
+          text = "${pkgs.colmena}/bin/colmena build";
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -4,23 +4,95 @@
   inputs = {
     holonix.url = "github:holochain/holonix?ref=main-0.4";
     nixpkgs.follows = "holonix/nixpkgs";
+    flake-parts.follows = "holonix/flake-parts";
+    pre-commit-hooks = {
+      url = "github:cachix/pre-commit-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { ... }@inputs:
-    let
-      system = "x86_64-linux";
-      pkgs = import inputs.nixpkgs {
-        inherit system;
-        config.allowUnfreePredicate = pkg: builtins.elem (inputs.nixpkgs.lib.getName pkg) [ "nomad" ];
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = [ "aarch64-darwin" "x86_64-linux" ];
+
+    perSystem = { self', pkgs, system, ... }: {
+      formatter = pkgs.nixpkgs-fmt;
+
+      checks.pre-commit = inputs.pre-commit-hooks.lib.${system}.run {
+        src = ./.;
+        hooks = {
+          # Nix
+          deadnix.enable = true;
+          nixpkgs-fmt.enable = true;
+          statix.enable = true;
+
+          # Spell checking
+          typos.enable = true;
+
+          # Git
+          check-merge-conflicts.enable = true;
+          no-commit-to-branch.enable = true;
+
+          # Whitespace
+          mixed-line-endings.enable = true;
+          trim-trailing-whitespace.enable = true;
+
+          # Markdown
+          markdownlint = {
+            enable = true;
+            settings.configuration = {
+              # Don't check line length in code blocks
+              line-length.code_blocks = false;
+            };
+          };
+          mdformat.enable = true;
+
+          # Private keys
+          detect-private-keys.enable = true;
+        };
       };
-    in
-    {
-      colmena = {
+
+
+      devShells.default = pkgs.mkShell {
+        packages = with pkgs; [
+          self'.checks.pre-commit.enabledPackages
+          colmena
+        ];
+
+        inherit (self'.checks.pre-commit) shellHook;
+      };
+
+      packages.default = pkgs.writeShellApplication {
+        name = "setup-script";
+        text = ''
+          if [[ -v 1 ]]; then
+              node="$1"
+          else
+              read -r -p "Enter node name: " node
+          fi
+
+          cd ${./.}
+          ${pkgs.colmena}/bin/colmena apply-local --sudo --impure --node="$node"
+          while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
+            sleep 0.5
+          done
+          ${pkgs.tailscale}/bin/tailscale up --ssh --hostname="$node"
+        '';
+      };
+    };
+
+    flake.colmena =
+      let
+        targetSystem = "x86_64-linux";
+      in
+      {
         meta = {
-          nixpkgs = pkgs;
+          nixpkgs = import inputs.nixpkgs {
+            system = targetSystem;
+            config.allowUnfreePredicate = pkg: builtins.elem (inputs.nixpkgs.lib.getName pkg) [ "nomad" ];
+          };
         };
 
-        defaults = { name, ... }: {
+        defaults = { name, pkgs, ... }: {
           deployment = {
             allowLocalDeployment = true;
           };
@@ -68,7 +140,7 @@
               bzip2
               telegraf
               # Enable unstable and non-default features that Wind Tunnel tests.
-              (inputs.holonix.packages.${system}.holochain.override { cargoExtraArgs = "--features chc,unstable-functions,unstable-countersigning"; })
+              (inputs.holonix.packages.${targetSystem}.holochain.override { cargoExtraArgs = "--features chc,unstable-functions,unstable-countersigning"; })
             ];
 
             # The Nomad configuration file
@@ -86,22 +158,5 @@
         };
       };
 
-      packages.${system}.default = pkgs.writeShellApplication {
-        name = "setup-script";
-        text = ''
-          if [[ -v 1 ]]; then
-              node="$1"
-          else
-              read -r -p "Enter node name: " node
-          fi
-
-          cd ${./.}
-          ${pkgs.colmena}/bin/colmena apply-local --sudo --impure --node="$node"
-          while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
-            sleep 0.5
-          done
-          ${pkgs.tailscale}/bin/tailscale up --ssh --hostname="$node"
-        '';
-      };
-    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -137,11 +137,6 @@
 
           boot.loader.grub.device = "/dev/sda";
 
-          fileSystems."/" = {
-            device = "/dev/sda1";
-            fsType = "ext4";
-          };
-
           users = {
             mutableUsers = false;
             users.root.hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
       nixos = { ... }: {
         deployment = {
           allowLocalDeployment = true;
+          targetHost = null; # Only used for local deployment
         };
 
         boot.loader.grub.device = "/dev/sda";

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,8 @@
             echo "Installation complete"
             echo "It is recommended to reboot for the hostname to take effect."
             while true; do
-              read -r -p "Reboot now? (y/n) " yn
+              read -r -n 1 -p 'Reboot now? [y/n] ' yn
+              echo ""
               case $yn in
                 [yY]*)
                   reboot now

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
             fi
 
             cd ${./.}
-            ${pkgs.colmena}/bin/colmena apply-local --sudo --impure --node="$node"
+            ${pkgs.colmena}/bin/colmena apply-local --impure --node="$node"
             while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
               sleep 0.5
             done
@@ -84,7 +84,7 @@
               read -r -p "Reboot now? (y/n) " yn
               case $yn in
                 [yY]*)
-                  sudo reboot now
+                  reboot now
                   break
                   ;;
                 [nN]*)

--- a/flake.nix
+++ b/flake.nix
@@ -42,10 +42,6 @@
             enable = true;
           };
         };
-
-        nixos = { ... }: {
-          deployment.targetHost = null; # Only used for local deployment
-        };
       };
 
       packages.${system}.default = pkgs.writeShellApplication {

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
             while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
               sleep 0.5
             done
-            ${pkgs.tailscale}/bin/tailscale up --ssh --advertise-tags=tag:nomad-client --hostname="$node"
+            ${pkgs.tailscale}/bin/tailscale up --ssh --advertise-tags=tag:nomad-client --accept-risk=lose-ssh --hostname="$node"
 
             echo "Installation complete"
             echo "It is recommended to reboot for the hostname to take effect."

--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,9 @@
           nixpkgs = pkgs;
         };
 
-        nixos = { name, ... }: {
+        defaults = { name, ... }: {
           deployment = {
             allowLocalDeployment = true;
-            targetHost = null; # Only used for local deployment
           };
 
           system.stateVersion = "24.11";
@@ -42,6 +41,10 @@
           services.tailscale = {
             enable = true;
           };
+        };
+
+        nixos = { ... }: {
+          deployment.targetHost = null; # Only used for local deployment
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,10 @@
           extraGroups = [ "networkmanager" "wheel" ];
           hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";
         };
+
+        services.tailscale = {
+          enable = true;
+        };
       };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,21 @@
             sleep 0.5
           done
           ${pkgs.tailscale}/bin/tailscale up --ssh --hostname="$node"
+
+          echo "Installation complete"
+          echo "It is recommended to reboot for the hostname to take effect."
+          while true; do
+            read -r -p "Reboot now? (y/n) " yn
+            case $yn in
+              [yY]*)
+                sudo reboot now
+                break
+                ;;
+              [nN]*)
+                break
+                ;;
+            esac
+          done
         '';
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
           while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
             sleep 0.5
           done
-          ${pkgs.tailscale}/bin/tailscale up --ssh
+          ${pkgs.tailscale}/bin/tailscale up --ssh --hostname="$node"
         '';
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -40,5 +40,13 @@
           };
         };
       };
+
+      packages.${system}.default = pkgs.writeShellApplication {
+        name = "setup-script";
+        text = ''
+          cd ${./.}
+          ${pkgs.colmena}/bin/colmena apply-local --sudo --impure "$@"
+        '';
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -61,37 +61,44 @@
         inherit (self'.checks.pre-commit) shellHook;
       };
 
-      packages.default = pkgs.writeShellApplication {
-        name = "setup-script";
-        text = ''
-          if [[ -v 1 ]]; then
-              node="$1"
-          else
-              read -r -p "Enter node name: " node
-          fi
+      packages = {
+        default = pkgs.writeShellApplication {
+          name = "setup-script";
+          text = ''
+            if [[ -v 1 ]]; then
+                node="$1"
+            else
+                read -r -p "Enter node name: " node
+            fi
 
-          cd ${./.}
-          ${pkgs.colmena}/bin/colmena apply-local --sudo --impure --node="$node"
-          while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
-            sleep 0.5
-          done
-          ${pkgs.tailscale}/bin/tailscale up --ssh --hostname="$node"
+            cd ${./.}
+            ${pkgs.colmena}/bin/colmena apply-local --sudo --impure --node="$node"
+            while ! ${pkgs.procps}/bin/pgrep "tailscaled" > /dev/null; do
+              sleep 0.5
+            done
+            ${pkgs.tailscale}/bin/tailscale up --ssh --hostname="$node"
 
-          echo "Installation complete"
-          echo "It is recommended to reboot for the hostname to take effect."
-          while true; do
-            read -r -p "Reboot now? (y/n) " yn
-            case $yn in
-              [yY]*)
-                sudo reboot now
-                break
-                ;;
-              [nN]*)
-                break
-                ;;
-            esac
-          done
-        '';
+            echo "Installation complete"
+            echo "It is recommended to reboot for the hostname to take effect."
+            while true; do
+              read -r -p "Reboot now? (y/n) " yn
+              case $yn in
+                [yY]*)
+                  sudo reboot now
+                  break
+                  ;;
+                [nN]*)
+                  break
+                  ;;
+              esac
+            done
+          '';
+        };
+
+        build = pkgs.writeShellApplication {
+          name = "build-script";
+          text = "${pkgs.colmena}/bin/colmena build --impure";
+        };
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,9 @@
         deployment = {
           allowLocalDeployment = true;
         };
+
         boot.loader.grub.device = "/dev/sda";
+
         fileSystems."/" = {
           device = "/dev/sda1";
           fsType = "ext4";
@@ -28,6 +30,7 @@
           isNormalUser = true;
           description = "Holochain Dev Account";
           extraGroups = [ "networkmanager" "wheel" ];
+          hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,11 @@
           name = "build-script";
           text = "${pkgs.colmena}/bin/colmena build";
         };
+
+        apply = pkgs.writeShellApplication {
+          name = "apply-script";
+          text = "${pkgs.colmena}/bin/colmena apply";
+        };
       };
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,15 @@
           nixpkgs = pkgs;
         };
 
-        nixos = { ... }: {
+        nixos = { name, ... }: {
           deployment = {
             allowLocalDeployment = true;
             targetHost = null; # Only used for local deployment
           };
 
           system.stateVersion = "24.11";
+
+          networking.hostName = name;
 
           boot.loader.grub.device = "/dev/sda";
 

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
 
           users = {
             mutableUsers = false;
-            users.root.hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";
+            users.root.hashedPassword = "$y$j9T$LEwPZpyLzb3CKDBEtAi.w1$Uxok0mk4i5AWJ0zbPaqfY6T7Bw5nNYteu69yxqD7Mg/";
           };
 
           services.tailscale = {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
         };
       };
 
-      nomad-client = { ... }: {
+      nixos = { ... }: {
         deployment = {
           allowLocalDeployment = true;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -6,36 +6,39 @@
     nixpkgs.follows = "holonix/nixpkgs";
   };
 
-  outputs = { ... }@inputs: {
-    colmena = {
-      meta = {
-        nixpkgs = import inputs.nixpkgs {
-          system = "x86_64-linux";
-        };
-      };
-
-      nixos = { ... }: {
-        deployment = {
-          allowLocalDeployment = true;
-          targetHost = null; # Only used for local deployment
+  outputs = { ... }@inputs:
+    let
+      system = "x86_64-linux";
+      pkgs = import inputs.nixpkgs { inherit system; };
+    in
+    {
+      colmena = {
+        meta = {
+          nixpkgs = pkgs;
         };
 
-        boot.loader.grub.device = "/dev/sda";
+        nixos = { ... }: {
+          deployment = {
+            allowLocalDeployment = true;
+            targetHost = null; # Only used for local deployment
+          };
 
-        fileSystems."/" = {
-          device = "/dev/sda1";
-          fsType = "ext4";
-        };
+          boot.loader.grub.device = "/dev/sda";
 
-        users = {
-          mutableUsers = false;
-          users.root.hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";
-        };
+          fileSystems."/" = {
+            device = "/dev/sda1";
+            fsType = "ext4";
+          };
 
-        services.tailscale = {
-          enable = true;
+          users = {
+            mutableUsers = false;
+            users.root.hashedPassword = "$y$j9T$4uoXeFexvI/s6fylf.UJd.$400SiovRcdEemmxWaFKniWK0a9ZEzwDB2MTn5.gqb70";
+          };
+
+          services.tailscale = {
+            enable = true;
+          };
         };
       };
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,8 @@
             targetHost = null; # Only used for local deployment
           };
 
+          system.stateVersion = "24.11";
+
           boot.loader.grub.device = "/dev/sda";
 
           fileSystems."/" = {


### PR DESCRIPTION
Closes holochain/holochain#4749

Adds a fleet of NixOS machines that can be managed with Colmena via SSH.
Adds a Tailscale network (tailnet) to connect the machines to allow SSH access without port-forwarding.

In the future, we could use Colmena's secret management to manage Tailscale tokens.