### PR TITLE
feat: add nomad-client-2 as a new node

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -189,6 +189,13 @@
             fsType = "ext4";
           };
         };
+
+        nomad-client-2 = _: {
+          fileSystems."/" = {
+            device = "/dev/disk/by-uuid/8dabb938-b5e5-4b81-8cd7-65266e25fd37";
+            fsType = "ext4";
+          };
+        };
       };
 
   };


### PR DESCRIPTION
Add a second client called `nomad-client-2`

Installation of this client has been successfully completed and so the client is available both in the Nomad cluster and in the tailnet.