### PR TITLE
docs: add comment for why tailscale_key file is ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 
 # Pre-commit hooks file as it is managed by Nix
 .pre-commit-config.yaml
+
+# Ignore so that we don't accidentally leak a private Tailscale key
 tailscale_key


### PR DESCRIPTION
I missed this comment when going back-and-forth on ignoring or using the `tailscale_key` file.