### PR TITLE
feat: add custom isUEFI option, used to select the bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ in
   # ...other config...
 
   <your-machine-name> = _: {
+    isUEFI = true;
+
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/<uuid-of-main-drive>";
       fsType = "ext4";
@@ -181,12 +183,11 @@ override the bootloader for your node only to switch to GRUB:
 <your-machine-name> = _: {
   # ...other config...
 
+  isUEFI = false; # This will use GRUB instead of systemd-boot as the bootloader
+
   boot.loader = {
-    systemd-boot.enable = false;
     grub = {
-      enable = true;
-      device = "/dev/sda";  # Change to mounted drive where GRUB is/should be installed
-      # useOSProber = true; # Uncomment if dual-booting with another OS
+      # Override GRUB settings here if required.
     };
   };
 };

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ The new machine should be listed on the Tailscale dashboard at
 To approve the machine, select the `...` dropdown on the right of the machine
 and select `Approve`.
 
-Change the name of the machine/node in Tailscale by selecting the `...`
-dropdown on the right of the machine and select `Edit machine name...`. The
-name should be unique and recognisable so that you know which node belongs to
-you, something like `nomad-client-<user>` is common practice with a base-one
-index after it, if you have multiple machines, i.e.
-`nomad-client-<user>-<index>`.
+Take note of whether the node is called `nomad-client-uefi` or
+`nomad-client-no-uefi`, as this will be important later. Then, change the name
+of the machine/node in Tailscale by selecting the `...` dropdown on the right
+of the machine and select `Edit machine name...`. The name should be unique and
+recognisable so that you know which node belongs to you, something like
+`nomad-client-<user>` is common practice with a base-one index after it, if you
+have multiple machines, i.e. `nomad-client-<user>-<index>`.
 
 > \[!Note\]
 > Changing the node name in Tailscale will not immediately change the hostname
@@ -85,7 +86,10 @@ index after it, if you have multiple machines, i.e.
 
 Finally, add the new machine as a "node" to the `Colmena` definition in the
 [colmena.nix](colmena.nix) file, the name of the machine should match the name
-in the Tailscale dashboard.
+in the Tailscale dashboard and the value of `isUEFI` should be set based on the
+original machine name where it should be set to `true` if the name was
+`nomad-client-uefi` and `false` if the original name was
+`nomad-client-no-uefi`.
 
 ```nix
 inputs:
@@ -95,7 +99,10 @@ in
 {
   # ...other config...
 
-  <your-machine-name> = _: { };
+  <your-machine-name> = _: {
+    isUEFI = true; # if name was `nomad-client-uefi`
+    isUEFI = false; # if name was `nomad-client-no-uefi`
+  };
 }
 ```
 

--- a/base-install.nix
+++ b/base-install.nix
@@ -1,126 +1,142 @@
-{ pkgs, lib, inputs, ... }:
+{ pkgs, lib, config, inputs, ... }:
 let
   # Set a value with a lower priority than `lib.mkDefault`
   mkBaseDefault = value: lib.mkOverride 1200 value;
 in
 {
-  boot = {
-    # Kernel modules available for use during the boot process. Must include all modules necessary for mounting the root device
-    initrd.availableKernelModules = [
-      "ata_piix"
-      "xhci_pci"
-      "ohci_pci"
-      "ehci_pci"
-      "ahci"
-      "nvme"
-      "sd_mod"
-      "sr_mod"
-    ];
+  options.isUEFI = lib.mkOption {
+    type = lib.types.bool;
+    description = "Does the system support a UEFI bootloader";
   };
 
-  # Mount the root file system
-  fileSystems."/" = mkBaseDefault {
-    device = "/dev/disk/by-label/nixos";
-    fsType = "ext4";
-  };
-
-  # Enable the swap partition
-  swapDevices = [{ device = "/dev/disk/by-label/swap"; }];
-
-  # Set the system type
-  nixpkgs.hostPlatform = "x86_64-linux";
-
-  # Allow proprietary/unfree packages to be installed
-  nixpkgs.config.allowUnfree = true;
-
-  nix = {
-    # Set nixpkgs version to the latest unstable version
-    package = pkgs.nixVersions.latest;
-
-    # Enable the `nix` command and `flakes`
-    extraOptions = "experimental-features = nix-command flakes";
-
-    # Add wind-tunnel substituters
-    settings = {
-      substituters = [ "https://cache.nixos.org" "https://holochain-ci.cachix.org" "https://holochain-wind-tunnel.cachix.org" ];
-      trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=" "holochain-wind-tunnel.cachix.org-1:tnSm+7Y3hDKOc9xLdoVMuInMA2AQ0R/99Ucz5edYGJw=" ];
-    };
-  };
-
-  networking = {
-    # Set the default machine's name
-    hostName = mkBaseDefault "nomad-client";
-
-    # Enable DHCP for all network devices
-    useDHCP = true;
-  };
-
-  users = {
-    # Disable using `passwd` to change user passwords
-    mutableUsers = false;
-
-    # Set the password of the root user to the one in the password manager
-    extraUsers.root.hashedPassword = mkBaseDefault "$y$j9T$LEwPZpyLzb3CKDBEtAi.w1$Uxok0mk4i5AWJ0zbPaqfY6T7Bw5nNYteu69yxqD7Mg/";
-  };
-
-  services = {
-    getty.helpLine = ''
-      ██╗    ██╗██╗███╗   ██╗██████╗     ████████╗██╗   ██╗███╗   ██╗███╗   ██╗███████╗██╗
-      ██║    ██║██║████╗  ██║██╔══██╗    ╚══██╔══╝██║   ██║████╗  ██║████╗  ██║██╔════╝██║
-      ██║ █╗ ██║██║██╔██╗ ██║██║  ██║       ██║   ██║   ██║██╔██╗ ██║██╔██╗ ██║█████╗  ██║
-      ██║███╗██║██║██║╚██╗██║██║  ██║       ██║   ██║   ██║██║╚██╗██║██║╚██╗██║██╔══╝  ██║
-      ╚███╔███╔╝██║██║ ╚████║██████╔╝       ██║   ╚██████╔╝██║ ╚████║██║ ╚████║███████╗███████╗
-       ╚══╝╚══╝ ╚═╝╚═╝  ╚═══╝╚═════╝        ╚═╝    ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═══╝╚══════╝╚══════╝
-                        ██████╗ ██╗   ██╗███╗   ██╗███╗   ██╗███████╗██████╗
-                        ██╔══██╗██║   ██║████╗  ██║████╗  ██║██╔════╝██╔══██╗
-                        ██████╔╝██║   ██║██╔██╗ ██║██╔██╗ ██║█████╗  ██████╔╝
-                        ██╔══██╗██║   ██║██║╚██╗██║██║╚██╗██║██╔══╝  ██╔══██╗
-                        ██║  ██║╚██████╔╝██║ ╚████║██║ ╚████║███████╗██║  ██║
-                        ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝
-    '';
-
-    # Enable Tailscale, used for SSH access
-    tailscale = {
-      enable = true;
-      authKeyFile = "/root/secrets/tailscale_key";
-      extraUpFlags = [ "--ssh" "--advertise-tags=tag:nomad-client" ];
-    };
-
-    # Enable Nomad as a client node
-    nomad = {
-      enable = true;
-      dropPrivileges = false; # Clients require root privileges
-
-      extraPackages = with pkgs; [
-        coreutils
-        bash
-        hexdump
-        gnutar
-        bzip2
-        telegraf
-        # Enable unstable and non-default features that Wind Tunnel tests.
-        (inputs.holonix.packages.x86_64-linux.holochain.override { cargoExtraArgs = "--features chc,unstable-functions,unstable-countersigning"; })
+  config = {
+    boot = {
+      # Kernel modules available for use during the boot process. Must include all modules necessary for mounting the root device
+      initrd.availableKernelModules = [
+        "ata_piix"
+        "xhci_pci"
+        "ohci_pci"
+        "ehci_pci"
+        "ahci"
+        "nvme"
+        "sd_mod"
+        "sr_mod"
       ];
 
-      # The Nomad configuration file
+      loader = {
+        grub = {
+          enable = !config.isUEFI;
+          device = lib.mkIf (!config.isUEFI) (mkBaseDefault "/dev/sda");
+        };
+        systemd-boot.enable = config.isUEFI;
+        efi.canTouchEfiVariables = config.isUEFI;
+      };
+    };
+
+    # Mount the root file system
+    fileSystems."/" = mkBaseDefault {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+    };
+
+    # Enable the swap partition
+    swapDevices = [{ device = "/dev/disk/by-label/swap"; }];
+
+    # Set the system type
+    nixpkgs.hostPlatform = "x86_64-linux";
+
+    # Allow proprietary/unfree packages to be installed
+    nixpkgs.config.allowUnfree = true;
+
+    nix = {
+      # Set nixpkgs version to the latest unstable version
+      package = pkgs.nixVersions.latest;
+
+      # Enable the `nix` command and `flakes`
+      extraOptions = "experimental-features = nix-command flakes";
+
+      # Add wind-tunnel substituters
       settings = {
-        data_dir = "/var/lib/nomad";
-        plugin.raw_exec.config.enabled = true;
-        acl.enabled = true;
-        client = {
-          enabled = true;
-          servers = [ "nomad-server-01.holochain.org" ];
-          artifact.disable_filesystem_isolation = true;
+        substituters = [ "https://cache.nixos.org" "https://holochain-ci.cachix.org" "https://holochain-wind-tunnel.cachix.org" ];
+        trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" "holochain-ci.cachix.org-1:5IUSkZc0aoRS53rfkvH9Kid40NpyjwCMCzwRTXy+QN8=" "holochain-wind-tunnel.cachix.org-1:tnSm+7Y3hDKOc9xLdoVMuInMA2AQ0R/99Ucz5edYGJw=" ];
+      };
+    };
+
+    networking = {
+      # Set the default machine's name
+      hostName = mkBaseDefault "nomad-client";
+
+      # Enable DHCP for all network devices
+      useDHCP = true;
+    };
+
+    users = {
+      # Disable using `passwd` to change user passwords
+      mutableUsers = false;
+
+      # Set the password of the root user to the one in the password manager
+      extraUsers.root.hashedPassword = mkBaseDefault "$y$j9T$LEwPZpyLzb3CKDBEtAi.w1$Uxok0mk4i5AWJ0zbPaqfY6T7Bw5nNYteu69yxqD7Mg/";
+    };
+
+    services = {
+      getty.helpLine = ''
+        ██╗    ██╗██╗███╗   ██╗██████╗     ████████╗██╗   ██╗███╗   ██╗███╗   ██╗███████╗██╗
+        ██║    ██║██║████╗  ██║██╔══██╗    ╚══██╔══╝██║   ██║████╗  ██║████╗  ██║██╔════╝██║
+        ██║ █╗ ██║██║██╔██╗ ██║██║  ██║       ██║   ██║   ██║██╔██╗ ██║██╔██╗ ██║█████╗  ██║
+        ██║███╗██║██║██║╚██╗██║██║  ██║       ██║   ██║   ██║██║╚██╗██║██║╚██╗██║██╔══╝  ██║
+        ╚███╔███╔╝██║██║ ╚████║██████╔╝       ██║   ╚██████╔╝██║ ╚████║██║ ╚████║███████╗███████╗
+         ╚══╝╚══╝ ╚═╝╚═╝  ╚═══╝╚═════╝        ╚═╝    ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═══╝╚══════╝╚══════╝
+                          ██████╗ ██╗   ██╗███╗   ██╗███╗   ██╗███████╗██████╗
+                          ██╔══██╗██║   ██║████╗  ██║████╗  ██║██╔════╝██╔══██╗
+                          ██████╔╝██║   ██║██╔██╗ ██║██╔██╗ ██║█████╗  ██████╔╝
+                          ██╔══██╗██║   ██║██║╚██╗██║██║╚██╗██║██╔══╝  ██╔══██╗
+                          ██║  ██║╚██████╔╝██║ ╚████║██║ ╚████║███████╗██║  ██║
+                          ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═══╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝
+      '';
+
+      # Enable Tailscale, used for SSH access
+      tailscale = {
+        enable = true;
+        authKeyFile = "/root/secrets/tailscale_key";
+        extraUpFlags = [ "--ssh" "--advertise-tags=tag:nomad-client" ];
+      };
+
+      # Enable Nomad as a client node
+      nomad = {
+        enable = true;
+        dropPrivileges = false; # Clients require root privileges
+
+        extraPackages = with pkgs; [
+          coreutils
+          bash
+          hexdump
+          gnutar
+          bzip2
+          telegraf
+          # Enable unstable and non-default features that Wind Tunnel tests.
+          (inputs.holonix.packages.x86_64-linux.holochain.override { cargoExtraArgs = "--features chc,unstable-functions,unstable-countersigning"; })
+        ];
+
+        # The Nomad configuration file
+        settings = {
+          data_dir = "/var/lib/nomad";
+          plugin.raw_exec.config.enabled = true;
+          acl.enabled = true;
+          client = {
+            enabled = true;
+            servers = [ "nomad-server-01.holochain.org" ];
+            artifact.disable_filesystem_isolation = true;
+          };
         };
       };
     };
-  };
 
-  # This value determines the NixOS release from which the default
-  # settings for stateful data, like file locations and database versions
-  # on your system were taken. It‘s perfectly fine and recommended to leave
-  # this value at the release version of the first install of this system.
-  # Before changing this value read the documentation for this option
-  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "24.11";
+    # This value determines the NixOS release from which the default
+    # settings for stateful data, like file locations and database versions
+    # on your system were taken. It‘s perfectly fine and recommended to leave
+    # this value at the release version of the first install of this system.
+    # Before changing this value read the documentation for this option
+    # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
+    system.stateVersion = "24.11";
+  };
 }

--- a/base-install.nix
+++ b/base-install.nix
@@ -64,7 +64,7 @@ in
 
     networking = {
       # Set the default machine's name
-      hostName = mkBaseDefault "nomad-client";
+      hostName = mkBaseDefault (if config.isUEFI then "nomad-client-uefi" else "nomad-client-no-uefi");
 
       # Enable DHCP for all network devices
       useDHCP = true;

--- a/colmena.nix
+++ b/colmena.nix
@@ -54,15 +54,6 @@ in
       device = "/dev/disk/by-uuid/8cd1f3a9-c743-42de-833a-6b9769ebd758";
       fsType = "ext4";
     };
-
-    boot.loader = {
-      systemd-boot.enable = false;
-      grub = {
-        enable = true;
-        device = "/dev/sda";
-        useOSProber = true;
-      };
-    };
   };
 
   nomad-client-cdunster = _: {

--- a/colmena.nix
+++ b/colmena.nix
@@ -11,7 +11,7 @@ in
     specialArgs = { inherit inputs; };
   };
 
-  defaults = { name, lib, ... }: {
+  defaults = { name, ... }: {
     imports = [ ./base-install.nix ];
 
     deployment = {
@@ -19,15 +19,11 @@ in
     };
 
     networking.hostName = name;
-
-    boot.loader = lib.mkDefault {
-      grub.enable = false;
-      systemd-boot.enable = true;
-      efi.canTouchEfiVariables = true;
-    };
   };
 
   nomad-client-1 = _: {
+    isUEFI = true;
+
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/a92690a8-d96c-4305-bfd9-ac4cf7f1c9e6";
       fsType = "ext4";
@@ -35,6 +31,8 @@ in
   };
 
   thetasinner-testoport = { config, ... }: {
+    isUEFI = true;
+
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/727efd61-af0f-4b5d-ab90-8b6fb3221c5b";
       fsType = "ext4";
@@ -50,6 +48,8 @@ in
   };
 
   nomad-client-zippy-hp-1 = _: {
+    isUEFI = false;
+
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/8cd1f3a9-c743-42de-833a-6b9769ebd758";
       fsType = "ext4";
@@ -65,11 +65,19 @@ in
     };
   };
 
-  nomad-client-cdunster = _: { };
+  nomad-client-cdunster = _: {
+    isUEFI = true;
+  };
 
-  jost-test-os-terone = _: { };
+  jost-test-os-terone = _: {
+    isUEFI = true;
+  };
 
-  nomad-client-zippy-hp-2 = _: { };
+  nomad-client-zippy-hp-2 = _: {
+    isUEFI = false;
+  };
 
-  nomad-client-zippy-hp-3 = _: { };
+  nomad-client-zippy-hp-3 = _: {
+    isUEFI = false;
+  };
 }

--- a/installer.nix
+++ b/installer.nix
@@ -4,13 +4,7 @@ let
     system = "x86_64-linux";
     modules = [
       ./base-install.nix
-      {
-        # Enable the GRUB bootloader and install it on `sda` drive
-        boot.loader.grub = {
-          enable = true;
-          device = "/dev/sda";
-        };
-      }
+      { isUEFI = false; }
     ];
     specialArgs = { inherit inputs; };
   };
@@ -18,13 +12,7 @@ let
     system = "x86_64-linux";
     modules = [
       ./base-install.nix
-      {
-        # Enable the systemd-boot bootloader with UEFI support
-        boot.loader = {
-          systemd-boot.enable = true;
-          efi.canTouchEfiVariables = true;
-        };
-      }
+      { isUEFI = true; }
     ];
     specialArgs = { inherit inputs; };
   };


### PR DESCRIPTION
The installation ISO will correctly install systemd-boot if UEFI is supported for the machine, otherwise, it will install GRUB. However, there is no easy way to propagate this decision, nor the detection of UEFI support to the Colmena configuration. Therefore, the current process has the default bootloader set to systemd-boot, which requires UEFI support and relies on the creator of the machine to override this default if there is no UEFI support and instead GRUB is required, see:
https://github.com/holochain/wind-tunnel-runner/blob/b2fc061cb5a7a913bc369c2d58f166f2627b6e22/colmena.nix#L58-L65

Unfortunately, the process wasn't clear about when to enable GRUB support for a node, and there aren't any checks in the PR, as only a `colmena apply` will fail if the bootloader is wrong, and that doesn't happen until the PR is merged. This caused a few nodes that require GRUB to not set GRUB as the bootloader, which caused failures when trying to switch to a new generation.

This PR adds a required option of `isUEFI` which must be set for every node. If it is `true`, then systemd-boot will be used as the bootloader with the correct options set; if it is `false`, then GRUB will be used with the device set to `/dev/sda`. As the option is required then it can't be accidentally missed. To make it easier for the users of the installation ISO to know what to set the value of `isUEFI` to, the default host name is now either `nomad-client-uefi` if it is supported and `isUEFI` should be set to `true`, otherwise it is `nomad-client-no-uefi`.