### PR TITLE
Add zippy holoports 4 & 5

### DIFF
--- a/colmena.nix
+++ b/colmena.nix
@@ -71,4 +71,13 @@ in
   nomad-client-zippy-hp-3 = _: {
     isUEFI = false;
   };
+
+  nomad-client-zippy-hp-4 = _: {
+    isUEFI = false;
+  };
+
+  nomad-client-zippy-hp-5 = _: {
+    isUEFI = false;
+  };
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new Nomad client nodes: zippy-hp-4 and zippy-hp-5.
  * These nodes are available as deployment targets alongside existing zippy-hp clients and follow the same profile for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->