### PR TITLE
fix: lp-tool installation into nomad runner

### DIFF
--- a/base-install.nix
+++ b/base-install.nix
@@ -78,10 +78,6 @@ in
       extraUsers.root.hashedPassword = mkBaseDefault "$y$j9T$LEwPZpyLzb3CKDBEtAi.w1$Uxok0mk4i5AWJ0zbPaqfY6T7Bw5nNYteu69yxqD7Mg/";
     };
 
-    environment.systemPackages = [
-      inputs.wind-tunnel.packages.x86_64-linux.lp-tool
-    ];
-
     services = {
       getty.helpLine = ''
         ██╗    ██╗██╗███╗   ██╗██████╗     ████████╗██╗   ██╗███╗   ██╗███╗   ██╗███████╗██╗
@@ -122,6 +118,7 @@ in
           # Enable unstable and non-default features that Wind Tunnel tests.
           (inputs.holonix.packages.x86_64-linux.holochain.override { cargoExtraArgs = "--features chc,unstable-functions,unstable-countersigning"; })
           inputs.holonix.packages.x86_64-linux.hc
+          inputs.wind-tunnel.packages.x86_64-linux.lp-tool
         ];
 
         # The Nomad configuration file


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Scoped lp-tool installation from system-wide to the Nomad client environment.
- **Impact**
  - lp-tool remains available for Nomad workloads but may no longer be accessible globally on the host.
- **Chores**
  - Reduced base system package footprint for cleaner, more targeted installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->