### PR TITLE
feat: allow running holochain bins from Wind Tunnel scenarios

### DIFF
--- a/base-install.nix
+++ b/base-install.nix
@@ -78,6 +78,9 @@ in
       extraUsers.root.hashedPassword = mkBaseDefault "$y$j9T$LEwPZpyLzb3CKDBEtAi.w1$Uxok0mk4i5AWJ0zbPaqfY6T7Bw5nNYteu69yxqD7Mg/";
     };
 
+    # Run dynamically-linked binaries such as Holochain on NixOS
+    programs.nix-ld.enable = true;
+
     services = {
       getty.helpLine = ''
         ██╗    ██╗██╗███╗   ██╗██████╗     ████████╗██╗   ██╗███╗   ██╗███╗   ██╗███████╗██╗


### PR DESCRIPTION
Upon completion of the Wind Tunnel issue (holochain/wind-tunnel#161), it will be possible to specify which `holochain` binary to use to start Holochain conductors. These binaries will be dynamically linked; for them to work on NixOS, [`nix-ld`](https://github.com/nix-community/nix-ld) is required to tell NixOS where to find the required libraries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to enable support for running dynamically linked binaries via nix-ld.
  * Improves compatibility with third-party tools and CLIs (e.g., Holochain) that rely on dynamic linking.
  * Disabled by default; users can enable the setting to run such binaries without extra configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->