### PR TITLE
chore: remove default holochain bins

### DIFF
--- a/base-install.nix
+++ b/base-install.nix
@@ -122,9 +122,6 @@ in
           influxdb2-cli
           jq
           telegraf
-          # Enable unstable and non-default features that Wind Tunnel tests.
-          (inputs.holonix.packages.x86_64-linux.holochain.override { cargoExtraArgs = "--features chc,unstable-functions,unstable-countersigning"; })
-          inputs.holonix.packages.x86_64-linux.hc
           inputs.wind-tunnel.packages.x86_64-linux.lp-tool
         ];
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,6 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1755537552,
-        "narHash": "sha256-Tg+P8kFIneqnQLT8E0QqlCrldtdLo1n1y619/mxRD44=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "3c40c97e1881fff381e4615e82557b333edf65c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_2": {
-      "locked": {
         "lastModified": 1754269165,
         "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
         "owner": "ipetkov",
@@ -30,7 +15,7 @@
         "type": "github"
       }
     },
-    "crane_3": {
+    "crane_2": {
       "locked": {
         "lastModified": 1750266157,
         "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
@@ -45,7 +30,7 @@
         "type": "github"
       }
     },
-    "crane_4": {
+    "crane_3": {
       "locked": {
         "lastModified": 1741021986,
         "narHash": "sha256-VX8M6arxQU05mipDmLjk0TJVRNzu+VQx3w1gVmyPkO4=",
@@ -99,24 +84,6 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_3": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
-      },
-      "locked": {
         "lastModified": 1749398372,
         "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
@@ -130,9 +97,9 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_3": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1740872218,
@@ -186,41 +153,7 @@
         "type": "github"
       }
     },
-    "hc-launch_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1751046670,
-        "narHash": "sha256-HHbFIY14lVcEpCc6sWiXu98VHcuCoAU+WTKJLFqvte8=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "ae0167461edd54913887e554e81e86a5c8de828b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-0.5",
-        "repo": "hc-launch",
-        "type": "github"
-      }
-    },
     "hc-scaffold": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755878805,
-        "narHash": "sha256-Tdvnu56gNs8QU7b6xQOKkToJZvMZasyLmyYSxS6lT+w=",
-        "owner": "holochain",
-        "repo": "scaffolding",
-        "rev": "d64bcd2363adbe4f641b7a2ad5b460fc686aa93f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "v0.500.2",
-        "repo": "scaffolding",
-        "type": "github"
-      }
-    },
-    "hc-scaffold_2": {
       "flake": false,
       "locked": {
         "lastModified": 1751016233,
@@ -240,23 +173,6 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1756748502,
-        "narHash": "sha256-3g5QLvCkzgSXfEhOyI3rzt5IEDXv0vrP0vGknGEbWZo=",
-        "owner": "holochain",
-        "repo": "holochain",
-        "rev": "d5f99fb7e2edb84f8993b9b0ce8e7381d3e6c1f1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-0.5.6",
-        "repo": "holochain",
-        "type": "github"
-      }
-    },
-    "holochain_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1752078164,
         "narHash": "sha256-Jl7l3z3LJ9nB/2yPwTUM5s5eYc1G+40lZ3rK2lpm5O4=",
         "owner": "holochain",
@@ -273,44 +189,16 @@
     },
     "holonix": {
       "inputs": {
-        "crane": "crane",
-        "flake-parts": "flake-parts",
+        "crane": "crane_2",
+        "flake-parts": "flake-parts_2",
         "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold",
         "holochain": "holochain",
         "kitsune2": "kitsune2",
         "lair-keystore": "lair-keystore",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "playground": "playground",
         "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1756931960,
-        "narHash": "sha256-F+p+XmYjlmdn0sfJPfU4EcW5TvihgHBA39yM9Ts8Jvs=",
-        "owner": "holochain",
-        "repo": "holonix",
-        "rev": "526083f735b3ef37ae20353946b26c8f7d8c646f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "main-0.5",
-        "repo": "holonix",
-        "type": "github"
-      }
-    },
-    "holonix_2": {
-      "inputs": {
-        "crane": "crane_3",
-        "flake-parts": "flake-parts_3",
-        "hc-launch": "hc-launch_2",
-        "hc-scaffold": "hc-scaffold_2",
-        "holochain": "holochain_2",
-        "kitsune2": "kitsune2_2",
-        "lair-keystore": "lair-keystore_2",
-        "nixpkgs": "nixpkgs_3",
-        "playground": "playground_2",
-        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "lastModified": 1752096312,
@@ -330,23 +218,6 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1755261441,
-        "narHash": "sha256-0XBAicjV/Y+luAf0NsQYnbKXzE0ByE9FB90suCFxmAQ=",
-        "owner": "holochain",
-        "repo": "kitsune2",
-        "rev": "12790940434fed3c913952fa103e39ce671fb0f0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "v0.1.14",
-        "repo": "kitsune2",
-        "type": "github"
-      }
-    },
-    "kitsune2_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1750424599,
         "narHash": "sha256-uY8f1hqUvS+8jd+2YKC0EPVG7HFEDXoWL0bOF7F1VQg=",
         "owner": "holochain",
@@ -361,12 +232,12 @@
         "type": "github"
       }
     },
-    "kitsune2_3": {
+    "kitsune2_2": {
       "inputs": {
-        "crane": "crane_4",
-        "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_4",
-        "rust-overlay": "rust-overlay_3"
+        "crane": "crane_3",
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
         "lastModified": 1746114651,
@@ -400,35 +271,18 @@
         "type": "github"
       }
     },
-    "lair-keystore_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1750349209,
-        "narHash": "sha256-IUj2u8I2YSVZGrZ234mVCPENTg239LSG05TysoB3t+A=",
-        "owner": "holochain",
-        "repo": "lair",
-        "rev": "978e3569e6a9cf674d2f1fc380cc82a87a43c78a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "v0.6.2",
-        "repo": "lair",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755704039,
-        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
+        "lastModified": 1768178648,
+        "narHash": "sha256-kz/F6mhESPvU1diB7tOM3nLcBfQe7GU7GQCymRlTi/s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
+        "rev": "3fbab70c6e69c87ea2b6e48aa6629da2aa6a23b0",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -450,21 +304,6 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_3": {
-      "locked": {
         "lastModified": 1748740939,
         "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
@@ -478,7 +317,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_4": {
+    "nixpkgs-lib_3": {
       "locked": {
         "lastModified": 1740872140,
         "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
@@ -491,22 +330,6 @@
       }
     },
     "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1768178648,
-        "narHash": "sha256-kz/F6mhESPvU1diB7tOM3nLcBfQe7GU7GQCymRlTi/s=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3fbab70c6e69c87ea2b6e48aa6629da2aa6a23b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1751211869,
         "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
@@ -522,7 +345,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1740932899,
         "narHash": "sha256-F0qDu2egq18M3edJwEOAE+D+VQ+yESK6YWPRQBfOqq8=",
@@ -538,7 +361,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1754937576,
         "narHash": "sha256-3sWA5WJybUE16kIMZ3+uxcxKZY/JRR4DFBqLdSLBo7w=",
@@ -555,23 +378,6 @@
       }
     },
     "playground": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1753170537,
-        "narHash": "sha256-vnaU7xkEWXQ/Bg+IkZT+hkF3h/ZFQ31IFEURpoT8ew8=",
-        "owner": "darksoil-studio",
-        "repo": "holochain-playground",
-        "rev": "464d4220865aefd91cf9db19399dfa435c919db7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "darksoil-studio",
-        "ref": "main-0.5",
-        "repo": "holochain-playground",
-        "type": "github"
-      }
-    },
-    "playground_2": {
       "flake": false,
       "locked": {
         "lastModified": 1748941883,
@@ -613,37 +419,15 @@
     "root": {
       "inputs": {
         "flake-parts": [
-          "holonix",
+          "wind-tunnel",
           "flake-parts"
         ],
-        "holonix": "holonix",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks",
         "wind-tunnel": "wind-tunnel"
       }
     },
     "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "holonix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1755830208,
-        "narHash": "sha256-fMa/Hcg+4O2h+kl3gNPjtGSWPI8NtCl3LYMsejK6qGA=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "802a7b97f8ff672ba2dec70c9e354f51f844e796",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "wind-tunnel",
@@ -665,7 +449,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_3": {
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "wind-tunnel",
@@ -687,7 +471,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_4": {
+    "rust-overlay_3": {
       "inputs": {
         "nixpkgs": [
           "wind-tunnel",
@@ -726,12 +510,12 @@
     },
     "wind-tunnel": {
       "inputs": {
-        "crane": "crane_2",
-        "flake-parts": "flake-parts_2",
-        "holonix": "holonix_2",
-        "kitsune2": "kitsune2_3",
-        "nixpkgs": "nixpkgs_5",
-        "rust-overlay": "rust-overlay_4",
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "holonix": "holonix",
+        "kitsune2": "kitsune2_2",
+        "nixpkgs": "nixpkgs_4",
+        "rust-overlay": "rust-overlay_3",
         "unstable": "unstable"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,8 @@
   description = "NixOS configuration for a Nomad client, deployed using Colmena";
 
   inputs = {
-    holonix.url = "github:holochain/holonix?ref=main-0.5";
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-parts.follows = "holonix/flake-parts";
+    flake-parts.follows = "wind-tunnel/flake-parts";
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Once #22 and holochain/wind-tunnel#284 have been merged **and** users of the Nomad cluster, such as Unyt, have been migrated to the new way of working, then we no longer need to install `holochain` nor `hc` on the runners as the `holochain` binary is provided to the Nomad job and run directly. Therefore, they can be removed.

TODO:

- [x] Merge #22
- [x] Merge holochain/wind-tunnel#284
- [x] Migrate Unyt to the new way of working done in holochain/wind-tunnel#457 and now part of core scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched build tooling to Wind Tunnel instead of Holonix for improved long-term maintainability.
* **Refactor**
  * Removed overrides that enabled unstable Holochain features, reverting to default configurations for more predictable, stable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->