### PR TITLE
feat: use GRUB bootloader by default for all machines

### DIFF
--- a/base-install.nix
+++ b/base-install.nix
@@ -4,11 +4,6 @@ let
   mkBaseDefault = value: lib.mkOverride 1200 value;
 in
 {
-  options.isUEFI = lib.mkOption {
-    type = lib.types.bool;
-    description = "Does the system support a UEFI bootloader";
-  };
-
   config = {
     boot = {
       # Kernel modules available for use during the boot process. Must include all modules necessary for mounting the root device

--- a/base-install.nix
+++ b/base-install.nix
@@ -26,7 +26,7 @@ in
       loader = {
         grub = {
           enable = !config.isUEFI;
-          device = lib.mkIf (!config.isUEFI) (mkBaseDefault "/dev/sda");
+          device = "nodev";
         };
         systemd-boot.enable = config.isUEFI;
         efi.canTouchEfiVariables = config.isUEFI;

--- a/base-install.nix
+++ b/base-install.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, config, inputs, ... }:
+{ pkgs, lib, inputs, ... }:
 let
   # Set a value with a lower priority than `lib.mkDefault`
   mkBaseDefault = value: lib.mkOverride 1200 value;
@@ -27,9 +27,9 @@ in
         grub = {
           enable = true;
           device = "nodev";
-          efiSupport = config.isUEFI;
+          efiSupport = true;
+          efiInstallAsRemovable = true;
         };
-        efi.canTouchEfiVariables = config.isUEFI;
         efi.efiSysMountPoint = "/efi-boot";
       };
     };
@@ -72,7 +72,7 @@ in
 
     networking = {
       # Set the default machine's name
-      hostName = mkBaseDefault (if config.isUEFI then "nomad-client-uefi" else "nomad-client-no-uefi");
+      hostName = mkBaseDefault "nomad-client";
 
       # Enable DHCP for all network devices
       useDHCP = true;

--- a/base-install.nix
+++ b/base-install.nix
@@ -30,7 +30,15 @@ in
           efiSupport = config.isUEFI;
         };
         efi.canTouchEfiVariables = config.isUEFI;
+        efi.efiSysMountPoint = "/efi-boot";
       };
+    };
+
+    # Mount the EFI boot file system
+    fileSystems."/efi-boot" = {
+      device = "/dev/disk/by-label/boot";
+      fsType = "vfat";
+      options = [ "nofail" ];
     };
 
     # Mount the root file system

--- a/base-install.nix
+++ b/base-install.nix
@@ -25,10 +25,10 @@ in
 
       loader = {
         grub = {
-          enable = !config.isUEFI;
+          enable = true;
           device = "nodev";
+          efiSupport = config.isUEFI;
         };
-        systemd-boot.enable = config.isUEFI;
         efi.canTouchEfiVariables = config.isUEFI;
       };
     };

--- a/base-install.nix
+++ b/base-install.nix
@@ -5,7 +5,7 @@ let
 in
 {
   config = {
-    boot = {
+    boot = mkBaseDefault {
       # Kernel modules available for use during the boot process. Must include all modules necessary for mounting the root device
       initrd.availableKernelModules = [
         "ata_piix"

--- a/colmena.nix
+++ b/colmena.nix
@@ -22,8 +22,6 @@ in
   };
 
   nomad-client-1 = _: {
-    isUEFI = true;
-
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/a92690a8-d96c-4305-bfd9-ac4cf7f1c9e6";
       fsType = "ext4";
@@ -31,8 +29,6 @@ in
   };
 
   thetasinner-testoport = { config, ... }: {
-    isUEFI = true;
-
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/727efd61-af0f-4b5d-ab90-8b6fb3221c5b";
       fsType = "ext4";
@@ -48,36 +44,21 @@ in
   };
 
   nomad-client-zippy-hp-1 = _: {
-    isUEFI = false;
-
     fileSystems."/" = {
       device = "/dev/disk/by-uuid/8cd1f3a9-c743-42de-833a-6b9769ebd758";
       fsType = "ext4";
     };
   };
 
-  nomad-client-cdunster = _: {
-    isUEFI = true;
-  };
+  nomad-client-cdunster = _: { };
 
-  jost-test-os-terone = _: {
-    isUEFI = true;
-  };
+  jost-test-os-terone = _: { };
 
-  nomad-client-zippy-hp-2 = _: {
-    isUEFI = false;
-  };
+  nomad-client-zippy-hp-2 = _: { };
 
-  nomad-client-zippy-hp-3 = _: {
-    isUEFI = false;
-  };
+  nomad-client-zippy-hp-3 = _: { };
 
-  nomad-client-zippy-hp-4 = _: {
-    isUEFI = false;
-  };
+  nomad-client-zippy-hp-4 = _: { };
 
-  nomad-client-zippy-hp-5 = _: {
-    isUEFI = false;
-  };
-
+  nomad-client-zippy-hp-5 = _: { };
 }

--- a/installer.nix
+++ b/installer.nix
@@ -55,7 +55,7 @@ in
     script = with pkgs; ''
       set -euxo pipefail
 
-      wait-for() {
+      wait_for() {
         for _ in $(seq 10); do
           if $@; then
             return
@@ -65,7 +65,7 @@ in
         exit 1
       }
 
-      install-legacy() {
+      install_legacy() {
         echo "Legacy/BIOS system detected"
 
         if [ ! -b /dev/sda ]; then
@@ -86,7 +86,7 @@ in
 
         ${coreutils-full}/bin/sync
 
-        wait-for [ -b /dev/disk/by-label/nixos ]
+        wait_for [ -b /dev/disk/by-label/nixos ]
         mount /dev/disk/by-label/nixos /mnt
 
         ${util-linux}/bin/swapon /dev/sda2
@@ -100,7 +100,7 @@ in
         ${coreutils-full}/bin/cp /iso/tailscale_key /mnt/root/secrets/tailscale_key
       }
 
-      install-uefi() {
+      install_uefi() {
         echo "UEFI system detected"
 
         [ -b /dev/sda ] && dev=/dev/sda
@@ -124,25 +124,25 @@ in
 
         ${coreutils-full}/bin/sync
 
-        wait-for [ -b /dev/disk/by-partlabel/nixos ]
+        wait_for [ -b /dev/disk/by-partlabel/nixos ]
         ${e2fsprogs}/bin/mkfs.ext4 -L nixos /dev/disk/by-partlabel/nixos
 
-        wait-for [ -b /dev/disk/by-partlabel/swap ]
+        wait_for [ -b /dev/disk/by-partlabel/swap ]
         ${util-linux}/bin/mkswap -L swap /dev/disk/by-partlabel/swap
 
-        wait-for [ -b /dev/disk/by-partlabel/boot ]
+        wait_for [ -b /dev/disk/by-partlabel/boot ]
         ${dosfstools}/bin/mkfs.fat -F 32 -n boot /dev/disk/by-partlabel/boot
 
         ${coreutils-full}/bin/sync
 
-        wait-for [ -b /dev/disk/by-label/nixos ]
+        wait_for [ -b /dev/disk/by-label/nixos ]
         mount /dev/disk/by-label/nixos /mnt
 
-        wait-for [ -b /dev/disk/by-label/boot ]
+        wait_for [ -b /dev/disk/by-label/boot ]
         ${coreutils-full}/bin/mkdir -p /mnt/boot
         mount -o umask=077 /dev/disk/by-label/boot /mnt/boot
 
-        wait-for [ -b /dev/disk/by-label/swap ]
+        wait_for [ -b /dev/disk/by-label/swap ]
         ${util-linux}/bin/swapon /dev/disk/by-label/swap
 
         ${config.system.build.nixos-install}/bin/nixos-install \
@@ -154,7 +154,7 @@ in
         ${coreutils-full}/bin/cp /iso/tailscale_key /mnt/root/secrets/tailscale_key
       }
 
-      [ -d /sys/firmware/efi/efivars ] && install-uefi || install-legacy
+      [ -d /sys/firmware/efi/efivars ] && install_uefi || install_legacy
 
       ${systemd}/bin/systemctl poweroff
     '';

--- a/installer.nix
+++ b/installer.nix
@@ -104,6 +104,7 @@ in
         echo "UEFI system detected"
 
         [ -b /dev/sda ] && dev=/dev/sda
+        [ -b /dev/vda ] && dev=/dev/vda
         [ -b /dev/nvme0n1 ] && dev=/dev/nvme0n1
 
         if [ -z ''${dev+x} ]; then

--- a/installer.nix
+++ b/installer.nix
@@ -104,6 +104,8 @@ in
           --no-root-passwd \
           --cores 0
 
+        grub-install --target=i386-pc --boot-directory=/mnt/boot /dev/sda
+
         ${coreutils-full}/bin/mkdir -p /mnt/root/secrets
         ${coreutils-full}/bin/cp /iso/tailscale_key /mnt/root/secrets/tailscale_key
       }

--- a/installer.nix
+++ b/installer.nix
@@ -57,7 +57,7 @@ in
           if $@; then
             return
           fi
-          sleep 1
+          ${coreutils-full}/bin/sleep 1
         done
         exit 1
       }
@@ -67,10 +67,10 @@ in
       [ -d /sys/firmware/efi ] && [ -b /dev/nvme0n1 ] && dev=/dev/nvme0n1
 
       if [ -z ''${dev+x} ]; then
-        echo "Cannot find drive to install on, aborting"
+        ${coreutils-full}/bin/echo "Cannot find drive to install on, aborting"
         exit 1
       else
-        echo "Erasing $dev and installing Wind Tunnel Runner NixOS"
+        ${coreutils-full}/bin/echo "Erasing $dev and installing Wind Tunnel Runner NixOS"
       fi
 
       ${parted}/bin/parted -s "$dev" -- mklabel gpt \
@@ -113,7 +113,7 @@ in
         --no-root-passwd \
         --cores 0
 
-      grub-install --target=i386-pc --boot-directory=/mnt/boot "$dev"
+      ${grub2}/bin/grub-install --target=i386-pc --boot-directory=/mnt/boot "$dev"
 
       ${coreutils-full}/bin/mkdir -p /mnt/root/secrets
       ${coreutils-full}/bin/cp /iso/tailscale_key /mnt/root/secrets/tailscale_key

--- a/installer.nix
+++ b/installer.nix
@@ -27,6 +27,14 @@ in
     volumeID = "wind-tunnel-runner-installer";
   };
 
+  nix = {
+    # Set nixpkgs version to the latest unstable version
+    package = pkgs.nixVersions.latest;
+
+    # Enable the `nix` command and `flakes`
+    extraOptions = "experimental-features = nix-command flakes";
+  };
+
   services.getty.helpLine = ''
                        ██╗    ██╗██╗███╗   ██╗██████╗     ████████╗██╗   ██╗███╗   ██╗███╗   ██╗███████╗██╗
                        ██║    ██║██║████╗  ██║██╔══██╗    ╚══██╔══╝██║   ██║████╗  ██║████╗  ██║██╔════╝██║

--- a/installer.nix
+++ b/installer.nix
@@ -112,11 +112,9 @@ in
       wait_for [ -b /dev/disk/by-label/nixos ]
       mount /dev/disk/by-label/nixos /mnt
 
-      if [ -d /sys/firmware/efi ]; then
-        wait_for [ -b /dev/disk/by-label/boot ]
-        ${coreutils-full}/bin/mkdir -p /mnt/boot
-        mount -o umask=077 /dev/disk/by-label/boot /mnt/boot
-      fi
+      wait_for [ -b /dev/disk/by-label/boot ]
+      ${coreutils-full}/bin/mkdir -p /mnt/efi-boot
+      mount -o umask=077 /dev/disk/by-label/boot /mnt/efi-boot
 
       wait_for [ -b /dev/disk/by-label/swap ]
       ${util-linux}/bin/swapon /dev/disk/by-label/swap


### PR DESCRIPTION
Closes #18

This PR sets the default bootloader used by all machines to be GRUB instead of the current setup of using systemd-boot for EFI-enabled systems and GRUB for older BIOS-enabled systems. It achieves this by installing GRUB both in the MBR section of the drive to be used by older BIOS systems and also in an EFI partition. This is technically a waste of disk space because now we have two bootloaders on all devices, but the total space used is 514MiB, which is negligible. This comprises of 1MiB MBR + 1MiB GRUB for BIOS systems + 512MiB GRUB for EFI systems.

I have tested both the installation ISO and the Colmena apply command on a BIOS-enabled VM, an EFI-enabled VM, and a real EFI-enabled machine.

As discussed in the refinement meeting, it is recommended to reinstall on all existing machines to unify everything, but it should be possible to keep supporting old setups if desired.