### PR TITLE
chore: Add thetasinner HP test-o-ports

### DIFF
--- a/colmena.nix
+++ b/colmena.nix
@@ -67,6 +67,12 @@ in
     nixpkgs.config.allowBroken = true;
   };
 
+  nomad-client-thetasinner-hp-testoport-1 = _: { };
+
+  nomad-client-thetasinner-hp-testoport-2 = _: { };
+
+  nomad-client-thetasinner-hp-testoport-3 = _: { };
+
   nomad-client-zippy-hp-1 = _: {
     boot.loader.grub = {
       device = "/dev/sda";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new Nomad client presets: thetasinner-hp-testoport-1, -2, and -3.

* **Chores**
  * Expanded the deployment catalog with additional hardware profiles mirroring existing patterns; these new presets are placeholders without specific configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->