### PR TITLE
add a regular holoport to network hp-8-n

### DIFF
--- a/colmena.nix
+++ b/colmena.nix
@@ -146,5 +146,6 @@ in
 
   nomad-client-zippy-hp-6 = _: { };
   nomad-client-zippy-hp-7 = _: { };
+  nomad-client-zippy-hp-8-n = _: { };
 
 }


### PR DESCRIPTION
This node is a regular holoport, not a holoport plus.  Thus not an ssd drive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new top-level deployment configuration entry to the exported system configuration.
  * Entry is currently empty and does not change runtime behavior or functionality; no other configuration or control-flow changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->