### PR TITLE
fix: issues with new nodes

### DIFF
--- a/colmena.nix
+++ b/colmena.nix
@@ -2,6 +2,11 @@ inputs:
 let
   targetSystem = "x86_64-linux";
 
+  # Use this config as a base for a machine that doesn't support EFI boot and
+  # was setup with the old installer ISO, before
+  # https://github.com/holochain/wind-tunnel-runner/pull/24 was merged.
+  # Note: If you used the installer created by the CI you do *not* need to use
+  # this and the default should be fine.
   oldGrubOnlySystem = {
     boot.loader.grub = {
       device = "/dev/sda";
@@ -12,6 +17,11 @@ let
     fileSystems."/efi-boot".enable = false;
   };
 
+  # Use this config as a base for a machine that has EFI boot support and was
+  # setup with the old installer ISO, before
+  # https://github.com/holochain/wind-tunnel-runner/pull/24 was merged.
+  # Note: If you used the installer created by the CI you do *not* need to use
+  # this and the default should be fine.
   oldSystemdBootSystem = {
     boot.loader = {
       grub = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added two reusable boot presets to standardize GRUB vs systemd-boot variants.
  * Migrated many systems to reference these presets, replacing inline boot/EFI blocks.
  * Renamed several public entries to align with presets and converted others to empty stubs.
  * Added and exposed additional public system entries based on the new presets.
  * Removed redundant inline boot/EFI configurations to reduce duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->