### PR TITLE
fix: EFI mount point on jost-test-os-terone

### DIFF
--- a/colmena.nix
+++ b/colmena.nix
@@ -92,7 +92,13 @@ in
 
   nomad-client-cdunster = _: { };
 
-  jost-test-os-terone = _: oldSystemdBootSystem;
+  jost-test-os-terone = _: {
+    boot.loader = {
+      grub.enable = false;
+      systemd-boot.enable = true;
+      efi.canTouchEfiVariables = true;
+    };
+  };
 
   nomad-client-zippy-hp-2 = _: oldGrubOnlySystem;
   nomad-client-zippy-hp-3 = _: oldGrubOnlySystem;


### PR DESCRIPTION
The changes from #24 changed the mount location of the EFI boot partition to be `/efi-boot` instead of `/boot`. This was done to allow `/boot` to be used for the legacy bootloader. This new mount point is found using `/dev/disk/by-label/boot` but the nodes `nomad-client-1` and `thetasinner-testoport` were created before that partition label existed and so they manually set the root `/` mount point to a drive's UUID (as per the instruction back when they were created) therefore `oldSystemdBootSystem` sets the EFI mount point to the default `/boot` directory. This, however, doe not work for the `jost-test-os-terone` node as it was created on a newer but not newest version of the installer where the labels exist and the mounting is done by the default config so for that node I have added a custom config that works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bootloader configuration for a test system to enable systemd-boot with EFI variable modification support while disabling GRUB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->