### PR TITLE
ci: cache nix binaries to cachix

### DIFF
--- a/.github/workflows/create-installer-iso.yml
+++ b/.github/workflows/create-installer-iso.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
+      - name: Setup cachix
+        uses: cachix/cachix-action@v16
+        with:
+          name: holochain-ci
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
       - name: Build Installer ISO
         run: nix build .#installer-iso
 


### PR DESCRIPTION
Resolves #26 

Depends on https://github.com/holochain/hc-github-config/pull/52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated to set up external build caching (Cachix) prior to creating the installer ISO, improving build reliability and reducing rebuild times.
  * Infrastructure tweak boosts consistency of installer builds and streamlines release generation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->