### PR TITLE
docs: increase min memory requirement to 4GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ then please ignore these instructions.
 The minimum hardware requirements for running a node are:
 
 - 10GB Disk
-- 2GB RAM
+- 4GB RAM
 - An internet connection
 
 ### Using Auto-installation ISO


### PR DESCRIPTION
Nomad fails to run a scenario due to not having enough resources when the client only has 2GB of memory. Bumping requirement to 4GB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum RAM requirement to 4GB in system hardware requirements documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->