### PR TITLE
Feat/threefold

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,8 +58,8 @@ jobs:
           docker image push ghcr.io/holochain/wind-tunnel-runner:latest-${{ matrix.arch }}
 
           docker load -i result-threefold
-          docker tag wind-tunnel-runner-threefold:latest ghcr.io/holochain/wind-tunnel-runner-threefold-${{ matrix.arch }}
-          docker image push ghcr.io/holochain/wind-tunnel-runner-threefold-${{ matrix.arch }}
+          docker tag wind-tunnel-runner-threefold:latest ghcr.io/holochain/wind-tunnel-runner-threefold:latest-${{ matrix.arch }}
+          docker image push ghcr.io/holochain/wind-tunnel-runner-threefold:latest-${{ matrix.arch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -82,5 +82,20 @@ jobs:
             ghcr.io/holochain/wind-tunnel-runner:latest-amd64 \
             ghcr.io/holochain/wind-tunnel-runner:latest-arm64
           docker manifest push ghcr.io/holochain/wind-tunnel-runner:latest
+
+          docker manifest create ghcr.io/holochain/wind-tunnel-runner-threefold:latest \
+            ghcr.io/holochain/wind-tunnel-runner-threefold:latest-amd64 \
+            ghcr.io/holochain/wind-tunnel-runner-threefold:latest-arm64
+          docker manifest push ghcr.io/holochain/wind-tunnel-runner-threefold:latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-threefold-hub-flist:
+    needs: publish-manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish docker image to threefold hub as flist
+        run: |
+          curl -X POST -F image=ghcr.io/holochain/wind-tunnel-runner-threefold:latest \
+            -H "Authorization: bearer ${{ secrets.THREEFOLD_HUB_API_TOKEN }}" \
+            https://hub.grid.tf/api/flist/me/docker

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,6 +7,7 @@ on:
       - 'docker-image.nix'
       - 'nomad-settings.nix'
       - 'nomad-settings-docker.nix'
+      - 'nomad-settings-threefold.nix'
   workflow_dispatch:
 
 concurrency:
@@ -38,8 +39,10 @@ jobs:
           name: holochain-ci
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: Build docker image
-        run: nix build .#docker-image
+      - name: Build docker images
+        run: |
+          nix build .#docker-image --out-link result-docker
+          nix build .#docker-image-threefold --out-link result-threefold
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -48,11 +51,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish Docker image
+      - name: Publish Docker images
         run: |
-          docker load -i result
+          docker load -i result-docker
           docker tag wind-tunnel-runner:latest ghcr.io/holochain/wind-tunnel-runner:latest-${{ matrix.arch }}
           docker image push ghcr.io/holochain/wind-tunnel-runner:latest-${{ matrix.arch }}
+
+          docker load -i result-threefold
+          docker tag wind-tunnel-runner-threefold:latest ghcr.io/holochain/wind-tunnel-runner-threefold-${{ matrix.arch }}
+          docker image push ghcr.io/holochain/wind-tunnel-runner-threefold-${{ matrix.arch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 .pre-commit-config.yaml
 
 # Ignore the result directory of an ISO build so we don't commit it!
-result
+result*

--- a/README.md
+++ b/README.md
@@ -263,3 +263,43 @@ To do this go to <https://login.tailscale.com/admin/machines> and select the
 Now that the machine is registered on Tailscale, navigate to
 <https://nomad-server-01.holochain.org:4646/ui/clients> and check that the
 machine is also in the list of available Nomad clients.
+
+## Deploying nodes via Threefold Grid
+
+### Generate the flist
+
+The flist is automatically generated and published to the threefold registry
+by the CI workflow "Docker Build".
+
+Alternatively it can be done manually:
+
+1. Build the docker image:
+   `nix build .#docker-image-threefold && docker load < result`
+1. Publish the docker image to a container registry.
+1. Generate the flist via the Threefold Hub web interface.
+1. Get the url of the flist on the Threefold Hub web interface
+   under the "Homemade" tab.
+
+### Deploy a single node
+
+1. Get the
+   [tf-grid-cmd binary](https://github.com/threefoldtech/tfgrid-sdk-go/releases)
+
+1. Run the command:
+
+```bash
+tf-grid-cli deploy vm --cpu 2 --memory 8 --disk 20 --name <my hostname> \
+  --ssh <path to my ssh pub key> \
+  --flist https://hub.threefold.me/holochain.3bot/ghcr.io-holochain-wind-tunnel-runner-threefold-latest.flist \
+  --entrypoint /entrypoint.sh
+```
+
+### Cancel all deployed nodes
+
+1. Get the [tf-grid-cmd binary](https://github.com/threefoldtech/tfgrid-sdk-go/releases)
+
+1. Run the command to cancel all node contracts and stop deployments.
+
+```bash
+ tf-grid-cmd cancel contracts -a
+```

--- a/docker-image.nix
+++ b/docker-image.nix
@@ -1,4 +1,8 @@
-{ inputs, system ? "x86_64-linux" }:
+{ inputs
+, system ? "x86_64-linux"
+, nomadSettings
+, dockerSettings
+}:
 let
   # Use the given system's nixpkgs for the docker image
   linuxPkgs = import inputs.nixpkgs {
@@ -26,26 +30,28 @@ let
     };
   };
 
-  nomadJSON = (linuxPkgs.formats.json { }).generate "nomad.json" (import ./nomad-settings-docker.nix);
+  nomadJSON = (linuxPkgs.formats.json { }).generate "nomad.json" (import nomadSettings);
 
-  # Wrapper entrypoint that synchronizes the system clock via NTP before starting Nomad.
-  # Some runners have very behind system clocks which affects wind-tunnel scenarios.
-  entrypoint = linuxPkgs.writeShellScript "entrypoint.sh" ''
+  entrypointPath = "/entrypoint.sh";
+
+  entrypointScript = linuxPkgs.writeShellScript (builtins.baseNameOf entrypointPath) ''
+    # Wrapper entrypoint that synchronizes the system clock via NTP before starting Nomad.
+    # Some runners have very behind system clocks which affects wind-tunnel scenarios.
     ${linuxPkgs.chrony}/bin/chronyd -q 'server pool.ntp.org iburst' 'makestep 1 -1'
-    exec /bin/nomad agent -config=${nomadJSON}
-  '';
-in
-linuxPkgs.dockerTools.buildImage {
-  name = "wind-tunnel-runner";
-  tag = "latest";
 
-  fromImage = baseImages.${system};
-  copyToRoot = linuxPkgs.buildEnv {
+    exec ${linuxPkgs.nomad_1_11}/bin/nomad agent "-config=${nomadJSON}"
+  '';
+
+  baseRoot = linuxPkgs.buildEnv {
     name = "image-root";
     paths = with linuxPkgs; [
       # additional system packages
       iproute2
       cacert
+      iputils
+      kmod
+      procps
+      util-linux
 
       # wind-tunnel job packages
       hexdump
@@ -55,16 +61,41 @@ linuxPkgs.dockerTools.buildImage {
       nomad_1_11
       inputs.wind-tunnel.packages.${system}.lp-tool
     ];
+
+    pathsToLink = [ "/bin" ];
   };
+
+in
+linuxPkgs.dockerTools.buildLayeredImage {
+  inherit (dockerSettings) name;
+  tag = "latest";
+
+  fromImage = baseImages.${system};
+  contents = [ baseRoot ];
+
+  extraCommands = ''
+    # Ensure entrypointPath is a real file in the root (not a symlink).
+    #
+    # Threefold requires providing the entrypoint path at deploy-time,
+    # and does not seem to work with symlinked entrypoint paths.
+    install -Dm755 ${entrypointScript} .${entrypointPath}
+
+    # Ensure certs are real files, not symlinks
+    mkdir -p ./etc/ssl/certs
+    install -m644 ${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt ./etc/ssl/certs/ca-bundle.crt
+    install -m644 ${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt ./etc/ssl/certs/ca-certificates.crt
+  '';
   config = {
     Labels = {
       "org.opencontainers.image.source" = "https://github.com/holochain/wind-tunnel-runner";
     };
     Env = [
-      "SSL_CERT_FILE=${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-      "NIX_SSL_CERT_FILE=${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+      "SSL_CERT_DIR=/etc/ssl/certs"
+      "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+      "CURL_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt"
     ];
-    Cmd = [ "${entrypoint}" ];
+    Cmd = [ entrypointPath ];
     User = "root";
   };
 }

--- a/docker-image.nix
+++ b/docker-image.nix
@@ -2,6 +2,7 @@
 , system ? "x86_64-linux"
 , nomadSettings
 , dockerSettings
+,
 }:
 let
   # Use the given system's nixpkgs for the docker image
@@ -34,6 +35,17 @@ let
 
   entrypointPath = "/entrypoint.sh";
 
+  runtimeLdLibraryPath =
+    if system == "aarch64-linux" then
+      "/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu"
+    else
+      "/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu";
+
+  nixLdExecWrapper = linuxPkgs.writeShellScriptBin "wt-nix-ld-run" ''
+    export LD_LIBRARY_PATH='${runtimeLdLibraryPath}''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH'
+    exec "$@"
+  '';
+
   entrypointScript = linuxPkgs.writeShellScript (builtins.baseNameOf entrypointPath) ''
     # Wrapper entrypoint that synchronizes the system clock via NTP before starting Nomad.
     # Some runners have very behind system clocks which affects wind-tunnel scenarios.
@@ -45,6 +57,10 @@ let
   baseRoot = linuxPkgs.buildEnv {
     name = "image-root";
     paths = with linuxPkgs; [
+      # base userland required for task scripts
+      bash
+      coreutils
+
       # additional system packages
       iproute2
       cacert
@@ -57,6 +73,7 @@ let
       hexdump
       influxdb2-cli
       jq
+      nixLdExecWrapper
       telegraf
       nomad_1_11
       inputs.wind-tunnel.packages.${system}.lp-tool

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1754269165,
-        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "lastModified": 1770419512,
+        "narHash": "sha256-o8Vcdz6B6bkiGUYkZqFwH3Pv1JwZyXht3dMtS7RchIo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "rev": "2510f2cbc3ccd237f700bb213756a8f35c32d8d7",
         "type": "github"
       },
       "original": {
@@ -17,26 +17,11 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1750266157,
-        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
+        "lastModified": 1768873933,
+        "narHash": "sha256-CfyzdaeLNGkyAHp3kT5vjvXhA1pVVK7nyDziYxCPsNk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_3": {
-      "locked": {
-        "lastModified": 1741021986,
-        "narHash": "sha256-VX8M6arxQU05mipDmLjk0TJVRNzu+VQx3w1gVmyPkO4=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "5245473d6638a96da540e44372da96eebb97735a",
+        "rev": "0bda7e7d005ccb5522a76d11ccfbf562b71953ca",
         "type": "github"
       },
       "original": {
@@ -48,15 +33,31 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -66,11 +67,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -84,11 +85,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -97,21 +98,26 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "git-hooks": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "wind-tunnel",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1740872218,
-        "narHash": "sha256-ZaMw0pdoUKigLpv9HiNDH2Pjnosg7NBYMJlHTIsHEUo=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "3876f6b87db82f33775b1ef5ea343986105db764",
+        "lastModified": 1769939035,
+        "narHash": "sha256-Fok2AmefgVA0+eprw2NDwqKkPGEI5wvR+twiZagBvrg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "a8ca480175326551d6c4121498316261cbb5b260",
         "type": "github"
       },
       "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },
@@ -136,36 +142,41 @@
         "type": "github"
       }
     },
-    "hc-launch": {
-      "flake": false,
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "wind-tunnel",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1751046670,
-        "narHash": "sha256-HHbFIY14lVcEpCc6sWiXu98VHcuCoAU+WTKJLFqvte8=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "ae0167461edd54913887e554e81e86a5c8de828b",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
-        "owner": "holochain",
-        "ref": "holochain-0.5",
-        "repo": "hc-launch",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1751016233,
-        "narHash": "sha256-MfHygBYMH2oFbdj+D8izQK6+J0zjqUJbr1w4ixvP4iw=",
+        "lastModified": 1769104114,
+        "narHash": "sha256-Ebh8YW7J4VRAwhK9XQDf98nWAIvciddzdx7LbhZiwdI=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "85b33854ea7c4c32d714161e0a2a2267157f28b2",
+        "rev": "6749c80d54306e4c1ad5831ce2dbdbb9a283ee0c",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.500.1",
+        "ref": "v0.600.1-rc.0",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -173,16 +184,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1752078164,
-        "narHash": "sha256-Jl7l3z3LJ9nB/2yPwTUM5s5eYc1G+40lZ3rK2lpm5O4=",
+        "lastModified": 1769035817,
+        "narHash": "sha256-PVUIsifOy6fRcceBZraLKrPwq83MzRYyfuxDCohv514=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "ba3bcf4d0da1b3683f1f715fafa6b469d89721c1",
+        "rev": "b499bd881580f9e0dd8f4494aafd4b2093a06168",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.5.4",
+        "ref": "holochain-0.6.1-rc.0",
         "repo": "holochain",
         "type": "github"
       }
@@ -191,26 +202,24 @@
       "inputs": {
         "crane": "crane_2",
         "flake-parts": "flake-parts_2",
-        "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold",
         "holochain": "holochain",
         "kitsune2": "kitsune2",
         "lair-keystore": "lair-keystore",
         "nixpkgs": "nixpkgs_2",
-        "playground": "playground",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1752096312,
-        "narHash": "sha256-mP8nfNRBI+2swc3lCXzxLXyD6SAb7JHnAC17R0v6h+Q=",
+        "lastModified": 1769121828,
+        "narHash": "sha256-o1GUUg9FUADcTOU4gzDDtiuJo61PyrQHCn0e64HRJYU=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "5e00d7be074f3b4dcfd5340a14c7046ce000fccf",
+        "rev": "3e2a4b96b177aaaa233fd744ba82bfe308e85635",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "main-0.5",
+        "ref": "main-0.6",
         "repo": "holonix",
         "type": "github"
       }
@@ -218,38 +227,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1750424599,
-        "narHash": "sha256-uY8f1hqUvS+8jd+2YKC0EPVG7HFEDXoWL0bOF7F1VQg=",
+        "lastModified": 1768402558,
+        "narHash": "sha256-v7uEmcVGC6tDjrkEZHMJa9DdXnqXwwVxJx9GkZq9P/U=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "dfc57d4c3faeca1b12a5669776a93cd6b43e6d7c",
+        "rev": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.1.9",
-        "repo": "kitsune2",
-        "type": "github"
-      }
-    },
-    "kitsune2_2": {
-      "inputs": {
-        "crane": "crane_3",
-        "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_3",
-        "rust-overlay": "rust-overlay_2"
-      },
-      "locked": {
-        "lastModified": 1746114651,
-        "narHash": "sha256-+MCxcDBHNq0CH4fiLXdoXfj/NlvzMkCMEPyh2cXGrp8=",
-        "owner": "holochain",
-        "repo": "kitsune2",
-        "rev": "203e2d333a4134d09ed63af7e8a6f00797e09168",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "v0.1.8",
+        "ref": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -257,27 +244,27 @@
     "lair-keystore": {
       "flake": false,
       "locked": {
-        "lastModified": 1750349209,
-        "narHash": "sha256-IUj2u8I2YSVZGrZ234mVCPENTg239LSG05TysoB3t+A=",
+        "lastModified": 1759147598,
+        "narHash": "sha256-K8TkVlKAwS7uuSZC46oSHddtZTM2XGWUTNnjjYdC1bE=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "978e3569e6a9cf674d2f1fc380cc82a87a43c78a",
+        "rev": "8aa9ab1468e82a8bfb9bf1e65762efc51659d306",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.6.2",
+        "ref": "v0.6.3",
         "repo": "lair",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768178648,
-        "narHash": "sha256-kz/F6mhESPvU1diB7tOM3nLcBfQe7GU7GQCymRlTi/s=",
+        "lastModified": 1772956932,
+        "narHash": "sha256-M0yS4AafhKxPPmOHGqIV0iKxgNO8bHDWdl1kOwGBwRY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3fbab70c6e69c87ea2b6e48aa6629da2aa6a23b0",
+        "rev": "608d0cadfed240589a7eea422407a547ad626a14",
         "type": "github"
       },
       "original": {
@@ -289,11 +276,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
         "type": "github"
       },
       "original": {
@@ -304,11 +291,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -317,80 +304,51 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1740872140,
-        "narHash": "sha256-3wHafybyRfpUCLoE8M+uPVZinImg3xX+Nm6gEfN3G8I=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "lastModified": 1770562336,
+        "narHash": "sha256-ub1gpAONMFsT/GU2hV6ZWJjur8rJ6kKxdm9IlCT0j84=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d6c71932130818840fc8fe9509cf50be8c64634f",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d3702243441165a03f699f64416f635220f4f15.tar.gz"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1751211869,
-        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
+        "lastModified": 1768940263,
+        "narHash": "sha256-sJERJIYTKPFXkoz/gBaBtRKke82h4DkX3BBSsKbfbvI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
+        "rev": "3ceaaa8bc963ced4d830e06ea2d0863b6490ff03",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1740932899,
-        "narHash": "sha256-F0qDu2egq18M3edJwEOAE+D+VQ+yESK6YWPRQBfOqq8=",
+        "lastModified": 1770464364,
+        "narHash": "sha256-z5NJPSBwsLf/OfD8WTmh79tlSU8XgIbwmk6qB1/TFzY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1546c45c538633ae40b93e2d14e0bb6fd8f13347",
+        "rev": "23d72dabcb3b12469f57b37170fcbc1789bd7457",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1754937576,
-        "narHash": "sha256-3sWA5WJybUE16kIMZ3+uxcxKZY/JRR4DFBqLdSLBo7w=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ddae11e58c0c345bf66efbddbf2192ed0e58f896",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "playground": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1748941883,
-        "narHash": "sha256-YeLySFcUnDpbJPaNn5UF5LE3DlIYRlJLmknqqy7GHws=",
-        "owner": "darksoil-studio",
-        "repo": "holochain-playground",
-        "rev": "9962a33ce1d00c9d0a32724644032852dd88a083",
-        "type": "github"
-      },
-      "original": {
-        "owner": "darksoil-studio",
-        "ref": "main-0.5",
-        "repo": "holochain-playground",
         "type": "github"
       }
     },
@@ -403,11 +361,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755960406,
-        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "lastModified": 1772893680,
+        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
         "type": "github"
       },
       "original": {
@@ -436,11 +394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751251399,
-        "narHash": "sha256-y+viCuy/eKKpkX1K2gDvXIJI/yzvy6zA3HObapz9XZ0=",
+        "lastModified": 1768963622,
+        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b22d5ee8c60ed1291521f2dde48784edd6bf695b",
+        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
         "type": "github"
       },
       "original": {
@@ -453,58 +411,20 @@
       "inputs": {
         "nixpkgs": [
           "wind-tunnel",
-          "kitsune2",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1741055476,
-        "narHash": "sha256-52vwEV0oS2lCnx3c/alOFGglujZTLmObit7K8VblnS8=",
+        "lastModified": 1770606655,
+        "narHash": "sha256-rpJf+kxvLWv32ivcgu8d+JeJooog3boJCT8J3joJvvM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aefb7017d710f150970299685e8d8b549d653649",
+        "rev": "11a396520bf911e4ed01e78e11633d3fc63b350e",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_3": {
-      "inputs": {
-        "nixpkgs": [
-          "wind-tunnel",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1755052812,
-        "narHash": "sha256-Tjw2YP7Hz8+ibE8wJ+Ps65vh1lzAe5ozmoo9sdQ7rGg=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "433023cba5f4fa66b8b0fdbb8f91d420c9cc2527",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "unstable": {
-      "locked": {
-        "lastModified": 1754725699,
-        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -512,18 +432,18 @@
       "inputs": {
         "crane": "crane",
         "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
         "holonix": "holonix",
-        "kitsune2": "kitsune2_2",
-        "nixpkgs": "nixpkgs_4",
-        "rust-overlay": "rust-overlay_3",
-        "unstable": "unstable"
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgsUnstable": "nixpkgsUnstable",
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1756996721,
-        "narHash": "sha256-3rZNFSc3/ErD4Dhm23zOh35UHczt2RLmezokNiL0bew=",
+        "lastModified": 1773129998,
+        "narHash": "sha256-7rqmqzfs01SAo7ZBMzaaIOElPT/oQUPy+fV/ymeeWC8=",
         "owner": "holochain",
         "repo": "wind-tunnel",
-        "rev": "6cb9244ed0c758be9ce82c13f23ce98b9afa4cad",
+        "rev": "38d0014b5a9ad50320e30b9fe58bb07657bcf451",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,23 @@
         docker-image =
           assert system != "aarch64-darwin"
             || throw "Cannot build docker-image for system ${system} try 'nix build .#packages.x86_64-linux.docker-image' or 'nix build .#packages.aarch64-linux.docker-image' instead";
-          import ./docker-image.nix { inherit inputs system; };
+          import ./docker-image.nix {
+            inherit inputs system;
+            dockerSettings = {
+              name = "wind-tunnel-runner";
+            };
+            nomadSettings = ./nomad-settings-docker.nix;
+          };
+        docker-image-threefold =
+          assert system != "aarch64-darwin"
+            || throw "Cannot build docker-image-threefold for system ${system} try 'nix build .#packages.x86_64-linux.docker-image-threefold' or 'nix build .#packages.aarch64-linux.docker-image-threefold' instead";
+          import ./docker-image.nix {
+            inherit inputs system;
+            dockerSettings = {
+              name = "wind-tunnel-runner-threefold";
+            };
+            nomadSettings = ./nomad-settings-threefold.nix;
+          };
       };
     };
 

--- a/installer.nix
+++ b/installer.nix
@@ -11,8 +11,11 @@ in
     "${modulesPath}/installer/cd-dvd/installation-cd-minimal.nix"
   ];
 
+  image = {
+    baseName = lib.mkForce "wind-tunnel-runner-auto-installer";
+  };
+
   isoImage = {
-    isoBaseName = lib.mkForce "wind-tunnel-runner-auto-installer";
     volumeID = "wind-tunnel-runner-installer";
   };
 

--- a/nomad-settings-threefold.nix
+++ b/nomad-settings-threefold.nix
@@ -1,0 +1,8 @@
+let
+  base = import ./nomad-settings.nix;
+in
+base // {
+  client = base.client // {
+    node_pool = "threefold";
+  };
+}


### PR DESCRIPTION
Resolves #51 

- New docker image variant that sets the nomad pool to "threefold"
- CI publishes the new container as `wind-tunnel-runner-threefold:latest`
- CI publishes container to 3fold registry: https://hub.threefold.me/holochain.3bot/ghcr.io-holochain-wind-tunnel-runner-threefold-latest.flist
- Fix issue where entrypoint script never runs unless you use the nix store path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now builds and publishes an additional Threefold-targeted image variant, multi-arch manifests, and publishes a flist to the Threefold hub.

* **Documentation**
  * Added a step‑by‑step README section for deploying via Threefold Grid (flist generation, single/batch deploy, removal).

* **Chores**
  * Added example tfrobot deployment config and adjusted installer/image naming for auto-installer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->