### PR TITLE
feat: add NTP time synchronization via chronyd

### DIFF
--- a/base-install.nix
+++ b/base-install.nix
@@ -107,6 +107,18 @@ in
         extraUpFlags = [ "--ssh" "--advertise-tags=tag:nomad-client" ];
       };
 
+      # Disable systemd-timesyncd in favour of chrony.
+      timesyncd.enable = false;
+
+      # Enable chrony NTP service to keep the system clock synchronized.
+      # Some runners have very behind system clocks which affects wind-tunnel scenarios.
+      chrony = {
+        enable = true;
+        extraConfig = ''
+          makestep 1 -1
+        '';
+      };
+
       # Enable Nomad as a client node
       nomad = {
         enable = true;

--- a/docker-image.nix
+++ b/docker-image.nix
@@ -27,6 +27,13 @@ let
   };
 
   nomadJSON = (linuxPkgs.formats.json { }).generate "nomad.json" (import ./nomad-settings-docker.nix);
+
+  # Wrapper entrypoint that synchronizes the system clock via NTP before starting Nomad.
+  # Some runners have very behind system clocks which affects wind-tunnel scenarios.
+  entrypoint = linuxPkgs.writeShellScript "entrypoint.sh" ''
+    ${linuxPkgs.chrony}/bin/chronyd -q 'server pool.ntp.org iburst' 'makestep 1 -1'
+    exec /bin/nomad agent -config=${nomadJSON}
+  '';
 in
 linuxPkgs.dockerTools.buildImage {
   name = "wind-tunnel-runner";
@@ -57,7 +64,7 @@ linuxPkgs.dockerTools.buildImage {
       "SSL_CERT_FILE=${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
       "NIX_SSL_CERT_FILE=${linuxPkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
     ];
-    Cmd = [ "/bin/nomad" "agent" "-config=${nomadJSON}" ];
+    Cmd = [ "${entrypoint}" ];
     User = "root";
   };
 }


### PR DESCRIPTION
Add NTP time synchronization using chrony to both Docker and host runners to ensure accurate system clocks before wind-tunnel scenarios run.

- **Docker runner:** wrapper entrypoint script runs `chronyd -q` for a one-shot NTP sync before starting the Nomad agent
- **Host runner:** enable `services.chrony` as a persistent systemd service on NixOS host machines

closes <https://github.com/holochain/wind-tunnel/issues/514>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker images now perform an automatic clock synchronization step before starting services via a new startup wrapper.
  * Image startup updated to use the wrapper instead of directly invoking the service binary.
  * System time sync switched to chrony and the previous time-sync service disabled; configuration includes aggressive step adjustments.
  * Added explanatory comments documenting the clock-sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->