### PR TITLE
feat: drop-in Nomad config dir for per-client metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,45 @@ containers with:
 docker ps
 ```
 
+#### Setting Nomad client metadata
+
+In addition to its built-in configuration, the runner image loads any Nomad
+configuration files mounted into `/etc/nomad.d`. The agent is started with this
+directory as an extra
+[`-config`](https://developer.hashicorp.com/nomad/commands/agent#config) path
+alongside the baked-in config, and any values found there are merged over the
+defaults. This lets you attach optional, per-client settings at deploy time
+without rebuilding the image.
+
+For example, to advertise a UNYT agent public key as the `UNYT_AGENT_PUB_KEY`
+client meta field, create a file `nomad-meta.json`:
+
+```json
+{
+  "client": {
+    "meta": {
+      "UNYT_AGENT_PUB_KEY": "<your-base64-agent-public-key>"
+    }
+  }
+}
+```
+
+Then mount it into `/etc/nomad.d` when starting the container:
+
+```bash
+docker run --hostname <MY_HOSTNAME> --cgroupns=host --net=host --privileged \
+  -v "$(pwd)/nomad-meta.json:/etc/nomad.d/meta.json:ro" \
+  -d --rm ghcr.io/holochain/wind-tunnel-runner:latest
+```
+
+> [!Note]
+> Mount individual files into `/etc/nomad.d`, not a volume over the whole
+> directory. Mounting a volume over `/etc/nomad.d` would hide the image's
+> built-in configuration and the client would not start correctly.
+
+If you do not need any extra client configuration, omit the mount entirely;
+`/etc/nomad.d` is empty by default and the built-in configuration is used as-is.
+
 ### Manually
 
 #### Installing NixOS

--- a/docker-image.nix
+++ b/docker-image.nix
@@ -51,7 +51,10 @@ let
     # Some runners have very behind system clocks which affects wind-tunnel scenarios.
     ${linuxPkgs.chrony}/bin/chronyd -q 'server pool.ntp.org iburst' 'makestep 1 -1'
 
-    exec ${linuxPkgs.nomad_1_11}/bin/nomad agent "-config=${nomadJSON}"
+    # Also load any drop-in config files mounted into /etc/nomad.d at deploy
+    # time (e.g. client meta such as UNYT_AGENT_PUB_KEY). Files found here are
+    # merged over the baked config; an empty/absent set of files is a no-op.
+    exec ${linuxPkgs.nomad_1_11}/bin/nomad agent "-config=${nomadJSON}" -config=/etc/nomad.d
   '';
 
   baseRoot = linuxPkgs.buildEnv {
@@ -96,6 +99,11 @@ linuxPkgs.dockerTools.buildLayeredImage {
     # Threefold requires providing the entrypoint path at deploy-time,
     # and does not seem to work with symlinked entrypoint paths.
     install -Dm755 ${entrypointScript} .${entrypointPath}
+
+    # Provide a drop-in config directory for deploy-time Nomad config (e.g.
+    # client meta). It must exist so 'nomad agent -config=/etc/nomad.d' does
+    # not error; leaving it empty simply applies no overrides.
+    mkdir -p ./etc/nomad.d
 
     # Ensure certs are real files, not symlinks
     mkdir -p ./etc/ssl/certs


### PR DESCRIPTION
## Summary
- Load drop-in Nomad config from `/etc/nomad.d` in the Docker image, passed as an additional `nomad agent -config` path alongside the baked config, so deploy-time config files are merged in without rebuilding the image.
- Keep the baked config as a separate read-only `-config` (from the `/nix/store` path) so a deploy-time mount can only *add* config, never shadow the base.
- Document setting optional, per-client metadata via a JSON file mounted into `/etc/nomad.d`, using `UNYT_AGENT_PUB_KEY` as the worked example.

## Reference
Nomad's `agent -config` flag accepts a directory of config files and can be specified multiple times, with values merged across files: https://developer.hashicorp.com/nomad/commands/agent#config