### PR TITLE
fix: avoid deprecated 'system' alias warning during colmena build

### DIFF
--- a/colmena.nix
+++ b/colmena.nix
@@ -2,6 +2,11 @@ inputs:
 let
   targetSystem = "x86_64-linux";
 
+  nixpkgsForTarget = import inputs.nixpkgs {
+    system = targetSystem;
+    config.allowUnfreePredicate = pkg: builtins.elem (inputs.nixpkgs.lib.getName pkg) [ "nomad" ];
+  };
+
   # Use this config as a base for a machine that doesn't support EFI boot and
   # was setup with the old installer ISO, before
   # https://github.com/holochain/wind-tunnel-runner/pull/24 was merged.
@@ -19,10 +24,12 @@ let
 in
 {
   meta = {
-    nixpkgs = import inputs.nixpkgs {
-      system = targetSystem;
-      config.allowUnfreePredicate = pkg: builtins.elem (inputs.nixpkgs.lib.getName pkg) [ "nomad" ];
-    };
+    # Override the bare `system` attribute, which on recent nixpkgs is a
+    # deprecated alias for `stdenv.hostPlatform.system`. Colmena reads
+    # `.system` off this set (`inherit (npkgs) system` in its evaluator);
+    # without the override that read emits an "'system' has been renamed"
+    # evaluation warning. The value is identical to the system we import with.
+    nixpkgs = nixpkgsForTarget // { system = targetSystem; };
     specialArgs = { inherit inputs; };
   };
 


### PR DESCRIPTION
## Summary
- `colmena build` logged `evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`.
- Root cause is not in this repo's expressions: passing `system = "x86_64-linux"` to `import nixpkgs { ... }` does **not** warn. The warning only fires when the deprecated `pkgs.system` alias is *read*. Colmena's evaluator does exactly that — `inherit (npkgs) system;` in `src/nix/hive/eval.nix` reads `.system` off the package set provided via `meta.nixpkgs`.
- Fix: override the bare `system` attribute on that package set with the plain target-system string (`nixpkgsForTarget // { system = targetSystem; }`), so colmena's read no longer touches the deprecated alias. The value is identical to the system we import with, and every other attribute colmena consumes (`path`, `overlays`, `config`, `lib`) is preserved. This also shields us if upstream nixpkgs later promotes the alias to a hard error.

## Verification
- Drove colmena's own `eval.nix` (the exact path `colmena build` uses) to evaluate node `toplevel` derivations: `'has been renamed'` warnings went from **1 → 0**, across multiple varied nodes, all still evaluating to valid NixOS derivations.
- `nixpkgs-fmt --check`, `deadnix`, and `statix` all pass on the changed file.

## Note for reviewers — why a workaround rather than an upgrade
This is a workaround for an upstream colmena bug. The two "just upgrade" routes don't apply here:

- **Upgrading nixpkgs does not fix it — it is the cause.** The warning exists *because* nixpkgs is recent enough to deprecate `pkgs.system`; newer nixpkgs keeps (and will eventually harden) the deprecation. There is no forward nixpkgs version where this goes away.
- **Upgrading colmena has nothing released to upgrade to.** Colmena's latest release is `v0.4.0` (May 2023), which nixpkgs ships and which contains the buggy `inherit (npkgs) system;`. The fix exists only on unreleased `main` (`inherit (npkgs.stdenv.hostPlatform) system;`), with no tagged release in ~3 years. Adopting it would mean pinning a git commit and building colmena from source.

Given that, the override is the proportionate fix, and is forward-compatible: it re-adds `system` as a plain attribute on the set colmena reads, so the repo keeps working even if a future nixpkgs removes the alias entirely. It can be dropped once a colmena release containing the upstream fix reaches nixpkgs.

Closes #56
